### PR TITLE
feat(generate): reuse encoded vibes from a reference library

### DIFF
--- a/apps/server/src/assets.ts
+++ b/apps/server/src/assets.ts
@@ -37,6 +37,15 @@ async function findAssetPath(id: string): Promise<string | null> {
   return null;
 }
 
+/** The bytes behind an `/assets/<id>/file` path, for server-side use. */
+export async function readAssetBase64(path: string): Promise<string | null> {
+  const id = /\/assets\/([^/]+)/.exec(path)?.[1];
+  if (!id) return null;
+  const file = await findAssetPath(id);
+  if (!file) return null;
+  return Buffer.from(await Bun.file(file).arrayBuffer()).toString("base64");
+}
+
 const postBodySchema = z.object({
   imageBase64: z.string().min(1),
   contentType: z.string().min(1),

--- a/apps/server/src/collections.ts
+++ b/apps/server/src/collections.ts
@@ -3,7 +3,12 @@ import { join } from "node:path";
 import { Elysia } from "elysia";
 import { configDir } from "./paths";
 
-const COLLECTION_NAMES = ["characters", "situations", "styles"] as const;
+const COLLECTION_NAMES = [
+  "characters",
+  "situations",
+  "styles",
+  "references",
+] as const;
 type CollectionName = (typeof COLLECTION_NAMES)[number];
 
 function isCollectionName(value: string): value is CollectionName {
@@ -135,6 +140,26 @@ function byUpdatedAtDesc(a: CollectionRecord, b: CollectionRecord): number {
   const ua = typeof a.updatedAt === "string" ? a.updatedAt : "";
   const ub = typeof b.updatedAt === "string" ? b.updatedAt : "";
   return ub.localeCompare(ua);
+}
+
+/** Reads a collection from inside the server. The web owns the shape, so the
+ * caller narrows it. */
+export async function readCollection(
+  name: CollectionName
+): Promise<CollectionRecord[]> {
+  return load(name);
+}
+
+/** Replaces one record in place. Used to write back a cached encode. */
+export async function patchCollectionRecord(
+  name: CollectionName,
+  id: string,
+  patch: Record<string, unknown>
+): Promise<void> {
+  const current = await load(name);
+  const found = current.find((record) => record.id === id);
+  if (!found) return;
+  await upsert(name, { ...found, ...patch, id });
 }
 
 export const collectionsRouter = new Elysia({ prefix: "/collections" })

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -6,6 +6,7 @@ import { assetsRouter } from "./assets";
 import { collectionsRouter } from "./collections";
 import { imagesRouter } from "./library";
 import { novelaiRouter } from "./novelai";
+import { referencesRouter } from "./references";
 import { settingsRouter } from "./settings";
 import { tagsRouter } from "./tags";
 
@@ -26,6 +27,7 @@ const app = new Elysia()
   .use(tagsRouter)
   .use(collectionsRouter)
   .use(assetsRouter)
+  .use(referencesRouter)
   .get("/", () => "OK")
   .listen(env.PORT, () => {
     console.log(`Server is running on http://localhost:${env.PORT}`);

--- a/apps/server/src/references.ts
+++ b/apps/server/src/references.ts
@@ -1,0 +1,205 @@
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Elysia } from "elysia";
+import { z } from "zod";
+import { env } from "@nai-desktop-studio/env/server";
+import { createNovelAIClient } from "@nai-desktop-studio/novelai";
+import type { EncodeVibeBody } from "@nai-desktop-studio/novelai";
+import { readAssetBase64 } from "./assets";
+import { patchCollectionRecord, readCollection } from "./collections";
+import { configDir } from "./paths";
+import { getApiKey } from "./settings";
+
+/**
+ * The model a vibe is encoded against.
+ *
+ * An encode is model-specific: one made for a different model cannot be used.
+ * Pinning it is what lets the result be cached at all — otherwise switching the
+ * generation model would silently invalidate every stored encode, and the whole
+ * point of the library is that the 2 Anlas is paid once.
+ */
+const ENCODE_MODEL = "nai-diffusion-4-5-full";
+
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function encodedDir(): string {
+  return join(configDir(), "encoded-vibes");
+}
+
+function encodedPath(id: string): string {
+  return join(encodedDir(), `${id}.txt`);
+}
+
+async function readEncoded(id: string): Promise<string | null> {
+  const file = Bun.file(encodedPath(id));
+  return (await file.exists()) ? file.text() : null;
+}
+
+async function writeEncoded(id: string, encoded: string): Promise<void> {
+  await mkdir(encodedDir(), { recursive: true });
+  const target = encodedPath(id);
+  const tmp = `${target}.${crypto.randomUUID()}.tmp`;
+  await writeFile(tmp, encoded);
+  await rename(tmp, target).catch(async (error: unknown) => {
+    await rm(tmp, { force: true });
+    throw error;
+  });
+}
+
+export async function deleteEncoded(id: string): Promise<void> {
+  await rm(encodedPath(id), { force: true }).catch(() => undefined);
+}
+
+/** One library entry, as far as this endpoint needs to understand it. */
+type ReferenceRecord = {
+  id: string;
+  kind?: unknown;
+  imagePath?: unknown;
+  strength?: unknown;
+  infoExtracted?: unknown;
+  referenceType?: unknown;
+  fidelity?: unknown;
+  encodedAt?: unknown;
+};
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export type ResolvedReference = {
+  id: string;
+  kind: "vibe" | "reference";
+  /** Base64 of the source image. Empty for a vibe, which sends its encode. */
+  image: string;
+  /** The encode. Empty for a precise reference, which sends the image. */
+  encoded: string;
+  referenceType: string;
+  strength: number;
+  fidelity: number;
+};
+
+const resolveBodySchema = z.object({
+  ids: z.array(z.string().min(1)).min(1).max(32),
+});
+
+/**
+ * Turns library ids into what a generation request needs.
+ *
+ * A vibe is encoded here, once, and the result is kept on disk. Every later
+ * generation reads the file instead of spending 2 Anlas again — which is the
+ * reason the library exists. A precise reference is sent as the image itself,
+ * so it only has to be read back.
+ */
+async function resolveOne(
+  record: ReferenceRecord,
+  encodeVibe: (request: EncodeVibeBody) => Promise<string>
+): Promise<ResolvedReference | null> {
+  const kind = record.kind === "reference" ? "reference" : "vibe";
+  const imagePath =
+    typeof record.imagePath === "string" ? record.imagePath : "";
+  const strength = readNumber(record.strength, kind === "vibe" ? 0.6 : 1);
+  const fidelity = readNumber(record.fidelity, 1);
+  const referenceType =
+    typeof record.referenceType === "string"
+      ? record.referenceType
+      : "character&style";
+
+  if (kind === "reference") {
+    const image = await readAssetBase64(imagePath);
+    if (!image) return null;
+    return {
+      id: record.id,
+      kind,
+      image,
+      encoded: "",
+      referenceType,
+      strength,
+      fidelity,
+    };
+  }
+
+  const cached = await readEncoded(record.id);
+  if (cached) {
+    return {
+      id: record.id,
+      kind,
+      image: "",
+      encoded: cached,
+      referenceType,
+      strength,
+      fidelity,
+    };
+  }
+
+  const image = await readAssetBase64(imagePath);
+  if (!image) return null;
+
+  const encoded = await encodeVibe({
+    image,
+    information_extracted: readNumber(record.infoExtracted, 0.7),
+    model: ENCODE_MODEL,
+  });
+  await writeEncoded(record.id, encoded);
+  // The list shows which entries are already paid for, so record it where the
+  // web can read it without asking for the blob itself.
+  await patchCollectionRecord("references", record.id, {
+    encodedAt: new Date().toISOString(),
+  });
+
+  return {
+    id: record.id,
+    kind,
+    image: "",
+    encoded,
+    referenceType,
+    strength,
+    fidelity,
+  };
+}
+
+export const referencesRouter = new Elysia({ prefix: "/references" })
+  .post(
+    "/resolve",
+    async ({ body, set }) => {
+      const apiKey = await getApiKey();
+      if (!apiKey) {
+        set.status = 428;
+        return { error: "NovelAI API key is not configured" };
+      }
+      const { encodeVibe } = createNovelAIClient({
+        apiKey,
+        imageBase: env.NOVELAI_IMAGE_BASE,
+        apiBase: env.NOVELAI_API_BASE,
+      });
+
+      const records = (await readCollection("references")) as ReferenceRecord[];
+      const byId = new Map(records.map((record) => [record.id, record]));
+
+      // Sequential: each miss is a paid network call, and doing them at once
+      // only makes a rate limit more likely.
+      const items: ResolvedReference[] = [];
+      for (const id of body.ids) {
+        const record = byId.get(id);
+        if (!record) continue;
+        try {
+          const resolved = await resolveOne(record, encodeVibe);
+          if (resolved) items.push(resolved);
+        } catch (error) {
+          // One bad entry must not lose the rest of the run. The caller reports
+          // how many were dropped.
+          console.error(`[references] could not resolve ${id}:`, error);
+        }
+      }
+      return { items };
+    },
+    { body: resolveBodySchema }
+  )
+  .delete("/:id/encoded", async ({ params, set }) => {
+    if (!ID_PATTERN.test(params.id)) {
+      set.status = 400;
+      return { error: "Invalid id" };
+    }
+    await deleteEncoded(params.id);
+    await patchCollectionRecord("references", params.id, { encodedAt: null });
+    return { ok: true };
+  });

--- a/apps/web/src/features/generate/components/reference-settings.tsx
+++ b/apps/web/src/features/generate/components/reference-settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@nai-desktop-studio/ui/components/button";
+import { cn } from "@nai-desktop-studio/ui/lib/utils";
 import {
   Select,
   SelectContent,
@@ -8,12 +9,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@nai-desktop-studio/ui/components/select";
-import { ImagePlus, Trash2 } from "lucide-react";
+import { ImagePlus, Library, Trash2, X } from "lucide-react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { LabeledSlider } from "@/components/labeled-slider";
+import { assetUrl } from "@/features/library/collections";
 import { SegmentedControl } from "@/components/segmented-control";
+import { ReferencePickerDialog } from "@/features/reference-library/components/reference-picker-dialog";
+import { useReferences } from "@/features/reference-library/hooks/queries";
 import { useT } from "@/i18n/provider";
 import type { MessageKey } from "@/i18n/messages";
 
@@ -288,7 +292,12 @@ function I2iRow({
 type Props = {
   form: Pick<
     FormState,
-    "model" | "i2i" | "referenceMode" | "vibes" | "references"
+    | "model"
+    | "i2i"
+    | "referenceMode"
+    | "vibes"
+    | "references"
+    | "libraryReferenceIds"
   >;
   update: (patch: Partial<FormState>) => void;
 };
@@ -300,6 +309,14 @@ type Props = {
  * alongside either.
  */
 export function ReferenceSettings({ form, update }: Props) {
+  const [libraryOpen, setLibraryOpen] = useState(false);
+  const { references } = useReferences();
+  // Only the ones that still exist and match the current mode: a reference
+  // saved as a vibe cannot go out in a precise-reference run.
+  const picked = form.libraryReferenceIds.flatMap((id) => {
+    const found = references.find((entry) => entry.id === id);
+    return found && found.kind === form.referenceMode ? [found] : [];
+  });
   const t = useT();
   const referenceAvailable = supportsReferences(form.model);
 
@@ -500,7 +517,77 @@ export function ReferenceSettings({ form, update }: Props) {
             />
           </div>
         )}
+        {/* Saved references. Separate from the images added above because
+            these keep their encode: picking one again costs nothing, while a
+            fresh drop pays 2 Anlas every run. */}
+        <div className="space-y-1.5 border-t pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full justify-between rounded-sm! px-2 font-normal"
+            onClick={() => setLibraryOpen(true)}
+          >
+            <span
+              className={cn(
+                "truncate",
+                picked.length === 0 && "text-muted-foreground"
+              )}
+            >
+              {picked.length > 0
+                ? t("referenceLibrary.picked", { count: picked.length })
+                : t("referenceLibrary.open")}
+            </span>
+            <Library className="text-muted-foreground shrink-0" aria-hidden />
+          </Button>
+          {picked.length > 0 && (
+            <ul className="flex flex-wrap gap-1">
+              {picked.map((entry) => (
+                <li
+                  key={entry.id}
+                  className="bg-muted flex max-w-full items-center gap-1 rounded-full border py-0.5 pr-0.5 pl-1.5 text-[10px]"
+                >
+                  <img
+                    src={assetUrl(entry.imagePath)}
+                    alt=""
+                    className="size-4 shrink-0 rounded-full object-cover"
+                  />
+                  <span className="truncate">{entry.name}</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground hover:text-destructive size-4"
+                    title={t("generate.character.remove")}
+                    onClick={() =>
+                      update({
+                        libraryReferenceIds: form.libraryReferenceIds.filter(
+                          (id) => id !== entry.id
+                        ),
+                      })
+                    }
+                  >
+                    <X className="size-2.5" aria-hidden />
+                    <span className="sr-only">
+                      {t("generate.character.remove")}
+                    </span>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </section>
+
+      <ReferencePickerDialog
+        open={libraryOpen}
+        onOpenChange={setLibraryOpen}
+        kind={form.referenceMode}
+        selectedIds={form.libraryReferenceIds}
+        onSelectedChange={(libraryReferenceIds) =>
+          update({ libraryReferenceIds })
+        }
+      />
     </div>
   );
 }

--- a/apps/web/src/features/generate/constants.ts
+++ b/apps/web/src/features/generate/constants.ts
@@ -107,6 +107,7 @@ export const INITIAL_FORM: FormState = {
   referenceMode: "vibe",
   vibes: [],
   references: [],
+  libraryReferenceIds: [],
 };
 
 /**

--- a/apps/web/src/features/generate/hooks/use-anlas-estimate.ts
+++ b/apps/web/src/features/generate/hooks/use-anlas-estimate.ts
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useDeferredValue, useMemo } from "react";
 
+import { useReferences } from "@/features/reference-library/hooks/queries";
 import { useSettings } from "@/features/settings/hooks/queries";
 import { useT } from "@/i18n/provider";
 
@@ -18,7 +19,23 @@ import type { FormState } from "../types/generate";
 export function useAnlasEstimate(form: FormState, imageCount?: number) {
   const t = useT();
   const { data: settings } = useSettings();
+  const { references } = useReferences();
   const isOpus = settings?.plan === "opus";
+
+  // Library entries count towards the vibe total, but only the ones with no
+  // stored encode still cost the 2 Anlas — that is the whole point of saving
+  // them, so the figure on the button has to show it.
+  const picked = form.libraryReferenceIds.flatMap((id) => {
+    const found = references.find((entry) => entry.id === id);
+    return found && found.kind === form.referenceMode ? [found] : [];
+  });
+  const libraryVibes = form.referenceMode === "vibe" ? picked.length : 0;
+  const libraryUncached =
+    form.referenceMode === "vibe"
+      ? picked.filter((entry) => entry.encodedAt === null).length
+      : 0;
+  const libraryReferences =
+    form.referenceMode === "reference" ? picked.length : 0;
   const mode = settings?.generationMode ?? "queue";
 
   // useDeferredValue compares by reference identity, so passing a new object
@@ -32,10 +49,13 @@ export function useAnlasEstimate(form: FormState, imageCount?: number) {
       // A batch run covers several scenes, so the number of images is not
       // form.nSamples but scenes x nSamples. The caller knows the scene count.
       nSamples: imageCount ?? form.nSamples,
-      vibeCount: form.referenceMode === "vibe" ? form.vibes.length : 0,
+      vibeCount:
+        form.referenceMode === "vibe" ? form.vibes.length + libraryVibes : 0,
+      uncachedVibeCount:
+        form.referenceMode === "vibe" ? form.vibes.length + libraryUncached : 0,
       referenceCount:
         form.referenceMode === "reference" && supportsReferences(form.model)
-          ? form.references.length
+          ? form.references.length + libraryReferences
           : 0,
       i2iStrength: form.i2i?.strength ?? null,
       isOpus,
@@ -50,6 +70,9 @@ export function useAnlasEstimate(form: FormState, imageCount?: number) {
       form.referenceMode,
       form.vibes.length,
       form.references.length,
+      libraryVibes,
+      libraryUncached,
+      libraryReferences,
       form.i2i?.strength,
       isOpus,
       mode,
@@ -71,9 +94,9 @@ export function useAnlasEstimate(form: FormState, imageCount?: number) {
         n_samples: deferred.mode === "alternate" ? deferred.nSamples : 1,
         character_reference_count: deferred.referenceCount,
         vibe_reference_count: deferred.vibeCount,
-        // An ad-hoc vibe is encoded once per batch, so always count it as
-        // uncached.
-        uncached_vibe_count: deferred.vibeCount,
+        // An image dropped into the panel is encoded once per batch, so it is
+        // always uncached. A library entry that already has its encode is not.
+        uncached_vibe_count: deferred.uncachedVibeCount,
         // Opus makes small generations free, which changes the number shown on
         // the generate button.
         is_opus: deferred.isOpus,

--- a/apps/web/src/features/generate/hooks/use-generation-engine.ts
+++ b/apps/web/src/features/generate/hooks/use-generation-engine.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -7,12 +8,15 @@ import { useT } from "@/i18n/provider";
 
 import { ApiError } from "@/lib/api-client";
 
+import { resolveReferences } from "@/features/reference-library/lib/api";
+import { referencesQueryKey } from "@/features/reference-library/hooks/queries";
 import { useSettings } from "@/features/settings/hooks/queries";
 
 import { aspectOfSize } from "../constants";
 import { encodeVibe, generateImages, generateImageStream } from "../lib/api";
 import { buildGenerateRequest, type EncodedVibe } from "../lib/build-request";
 import type { GenerationJob } from "../lib/compose";
+import type { FormState } from "../types/generate";
 import type { GeneratedImage, GenerationSlot } from "../types/image";
 
 type EngineState = {
@@ -41,6 +45,7 @@ type Options = {
  */
 export function useGenerationEngine({ onImageSaved }: Options) {
   const t = useT();
+  const queryClient = useQueryClient();
   const { data: settings } = useSettings();
   const mode = settings?.generationMode ?? "queue";
   const [state, setState] = useState<EngineState>(IDLE);
@@ -129,6 +134,63 @@ export function useGenerationEngine({ onImageSaved }: Options) {
           );
         }
 
+        // Library entries are resolved by the server, which already holds the
+        // encode for anything used before. Only a first-time vibe spends the
+        // 2 Anlas here; everything else is a file read.
+        let libraryForm = first;
+        if (first.libraryReferenceIds.length > 0) {
+          try {
+            const resolved = await resolveReferences(first.libraryReferenceIds);
+            const dropped = first.libraryReferenceIds.length - resolved.length;
+            if (dropped > 0) {
+              toast.warning(t("referenceLibrary.dropped", { count: dropped }));
+            }
+            if (first.referenceMode === "vibe") {
+              encodedVibes = [
+                ...encodedVibes,
+                ...resolved
+                  .filter((entry) => entry.kind === "vibe")
+                  .map((entry) => ({
+                    encoded: entry.encoded,
+                    strength: entry.strength,
+                  })),
+              ];
+            } else {
+              libraryForm = {
+                ...first,
+                references: [
+                  ...first.references,
+                  ...resolved
+                    .filter((entry) => entry.kind === "reference")
+                    .map((entry) => ({
+                      id: entry.id,
+                      previewUrl: "",
+                      imageBase64: entry.image,
+                      referenceType:
+                        entry.referenceType as (typeof first.references)[number]["referenceType"],
+                      strength: entry.strength,
+                      fidelity: entry.fidelity,
+                    })),
+                ],
+              };
+            }
+            // A first-time encode flips the badge in the picker.
+            void queryClient.invalidateQueries({
+              queryKey: referencesQueryKey,
+            });
+          } catch {
+            toast.error(t("referenceLibrary.resolveError"));
+          }
+        }
+
+        // The resolved precise references belong to the run, not to one scene,
+        // so each job's form picks them up as it goes out.
+        const libraryReferences = libraryForm.references;
+        const withLibrary = (form: FormState): FormState =>
+          libraryReferences === first.references
+            ? form
+            : { ...form, references: libraryReferences };
+
         let index = 0;
         for (const job of jobs) {
           if (controller.signal.aborted) break;
@@ -137,7 +199,7 @@ export function useGenerationEngine({ onImageSaved }: Options) {
           if (mode === "alternate") {
             // One request covers this scene's whole set. A run of several
             // scenes is still several requests: a request carries one prompt.
-            const body = buildGenerateRequest(job.form, {
+            const body = buildGenerateRequest(withLibrary(job.form), {
               batchId,
               index,
               encodedVibes,
@@ -162,7 +224,7 @@ export function useGenerationEngine({ onImageSaved }: Options) {
           for (let n = 0; n < count; n++) {
             if (controller.signal.aborted) break;
             const slot = index++;
-            const body = buildGenerateRequest(job.form, {
+            const body = buildGenerateRequest(withLibrary(job.form), {
               batchId,
               index: slot,
               encodedVibes,
@@ -204,7 +266,7 @@ export function useGenerationEngine({ onImageSaved }: Options) {
         setState((current) => ({ ...current, isGenerating: false }));
       }
     },
-    [mode, onImageSaved, t]
+    [mode, onImageSaved, queryClient, t]
   );
 
   return { ...state, generate, cancel, removeImage, reset };

--- a/apps/web/src/features/generate/types/generate.ts
+++ b/apps/web/src/features/generate/types/generate.ts
@@ -51,6 +51,11 @@ export type FormState = {
   referenceMode: ReferenceMode;
   vibes: AdhocVibe[];
   references: AdhocReference[];
+  /**
+   * Saved reference entries picked for this run. Held as ids: the image and the
+   * encode stay on the server, so a run carries only the choice.
+   */
+  libraryReferenceIds: string[];
 };
 
 /**

--- a/apps/web/src/features/library/collections.ts
+++ b/apps/web/src/features/library/collections.ts
@@ -7,7 +7,12 @@ import { bytesToBase64 } from "@/lib/base64";
  * is owned here, and each feature normalizes what it reads. That keeps one
  * schema instead of two that can drift.
  */
-export const COLLECTIONS = ["characters", "situations", "styles"] as const;
+export const COLLECTIONS = [
+  "characters",
+  "situations",
+  "styles",
+  "references",
+] as const;
 export type CollectionName = (typeof COLLECTIONS)[number];
 
 export function listCollection(name: CollectionName) {

--- a/apps/web/src/features/reference-library/components/reference-picker-dialog.tsx
+++ b/apps/web/src/features/reference-library/components/reference-picker-dialog.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { Button } from "@nai-desktop-studio/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@nai-desktop-studio/ui/components/dialog";
+import { Input } from "@nai-desktop-studio/ui/components/input";
+import { Label } from "@nai-desktop-studio/ui/components/label";
+import { cn } from "@nai-desktop-studio/ui/lib/utils";
+import { Coins, ImagePlus, Loader2, Search, Trash2, Zap } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { GroupField, collectGroupNames } from "@/components/group-field";
+import { LabeledSlider } from "@/components/labeled-slider";
+import { readImageFile } from "@/features/generate/lib/image-file";
+import { REFERENCE_TYPES } from "@/features/generate/types/reference";
+import type { ReferenceType } from "@/features/generate/types/reference";
+import { assetUrl, uploadAsset } from "@/features/library/collections";
+import { useT } from "@/i18n/provider";
+
+import { useReferences } from "../hooks/queries";
+import {
+  createEmptyReference,
+  searchableReferenceText,
+  type ReferenceEntry,
+  type ReferenceKind,
+} from "../types/reference";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Only entries of this kind can be used in the current run. */
+  kind: ReferenceKind;
+  selectedIds: string[];
+  onSelectedChange: (ids: string[]) => void;
+};
+
+/**
+ * The saved reference images, and which of them this run uses.
+ *
+ * The badge on a tile is the point of the whole screen: an entry that has been
+ * encoded costs nothing to use again, and one that has not will spend 2 Anlas
+ * the first time it goes out. That is the difference between picking from here
+ * and dropping the same file in every time.
+ */
+export function ReferencePickerDialog({
+  open,
+  onOpenChange,
+  kind,
+  selectedIds,
+  onSelectedChange,
+}: Props) {
+  const t = useT();
+  const { references, save, remove } = useReferences();
+  const [query, setQuery] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const ofKind = useMemo(
+    () => references.filter((entry) => entry.kind === kind),
+    [references, kind]
+  );
+
+  const shown = useMemo(() => {
+    const text = query.trim().toLowerCase();
+    if (!text) return ofKind;
+    return ofKind.filter((entry) =>
+      searchableReferenceText(entry).includes(text)
+    );
+  }, [ofKind, query]);
+
+  const sections = useMemo(() => {
+    const map = new Map<string, ReferenceEntry[]>();
+    for (const entry of shown) {
+      const key = entry.groupName ?? "";
+      map.set(key, [...(map.get(key) ?? []), entry]);
+    }
+    return [...map.entries()]
+      .sort(([a], [b]) => {
+        if (!a) return 1;
+        if (!b) return -1;
+        return a.localeCompare(b, "ja");
+      })
+      .map(([key, items]) => ({
+        key: key || "__ungrouped__",
+        name: key || t("group.none"),
+        items,
+      }));
+  }, [shown, t]);
+
+  const editing = references.find((entry) => entry.id === editingId) ?? null;
+  const groupOptions = collectGroupNames(references);
+
+  async function add(file: File) {
+    const read = await readImageFile(file);
+    if (!read.ok) {
+      toast.error(
+        read.reason === "not-image"
+          ? t("reference.error.notImage")
+          : t("reference.error.tooLarge")
+      );
+      return;
+    }
+    URL.revokeObjectURL(read.previewUrl);
+    setBusy(true);
+    try {
+      const uploaded = await uploadAsset(
+        read.imageBase64,
+        file.type || "image/png"
+      );
+      const entry = createEmptyReference(
+        kind,
+        file.name.replace(/\.[^.]+$/, "") || t("referenceLibrary.newName"),
+        uploaded.path
+      );
+      await save.mutateAsync(entry);
+      setEditingId(entry.id);
+    } catch {
+      toast.error(t("referenceLibrary.saveError"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function toggle(id: string) {
+    onSelectedChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter((item) => item !== id)
+        : [...selectedIds, id]
+    );
+    setEditingId(id);
+  }
+
+  function patch(next: Partial<ReferenceEntry>) {
+    if (!editing) return;
+    save.mutate({
+      ...editing,
+      ...next,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[85vh] flex-col gap-3 sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>{t("referenceLibrary.title")}</DialogTitle>
+          <DialogDescription>
+            {t("referenceLibrary.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2">
+          <div className="relative min-w-0 flex-1">
+            <Search
+              className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2"
+              aria-hidden
+            />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={t("referenceLibrary.search")}
+              className="h-8 pl-7"
+            />
+          </div>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              event.target.value = "";
+              if (file) void add(file);
+            }}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            disabled={busy}
+            onClick={() => inputRef.current?.click()}
+          >
+            {busy ? <Loader2 className="animate-spin" /> : <ImagePlus />}
+            {t("referenceLibrary.add")}
+          </Button>
+        </div>
+
+        <div className="flex min-h-0 flex-1 gap-3">
+          <div className="-mx-1 min-h-0 min-w-0 flex-1 overflow-y-auto px-1">
+            {sections.length === 0 ? (
+              <div className="text-muted-foreground flex h-full min-h-40 items-center justify-center rounded-md border border-dashed p-4 text-center text-xs leading-relaxed">
+                {ofKind.length === 0
+                  ? t("referenceLibrary.empty")
+                  : t("referenceLibrary.noMatch")}
+              </div>
+            ) : (
+              <div className="space-y-4 pb-1">
+                {sections.map((section) => (
+                  <section key={section.key} className="space-y-2">
+                    <div className="flex items-center gap-1.5 border-b pb-1">
+                      <h3 className="text-xs font-medium">{section.name}</h3>
+                      <span className="text-muted-foreground/70 font-mono text-[10px] tabular-nums">
+                        {section.items.length}
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+                      {section.items.map((entry) => {
+                        const order = selectedIds.indexOf(entry.id);
+                        const selected = order >= 0;
+                        return (
+                          <button
+                            key={entry.id}
+                            type="button"
+                            onClick={() => toggle(entry.id)}
+                            aria-pressed={selected}
+                            className={cn(
+                              "bg-card relative flex flex-col overflow-hidden rounded-lg border text-left transition-[border-color,box-shadow] duration-150 ease-out",
+                              selected
+                                ? "ring-primary ring-offset-popover ring-2 ring-offset-2"
+                                : "hover:border-primary/40",
+                              entry.id === editingId &&
+                                !selected &&
+                                "border-primary"
+                            )}
+                          >
+                            <span className="bg-muted flex aspect-square w-full items-center justify-center overflow-hidden">
+                              <img
+                                src={assetUrl(entry.imagePath)}
+                                alt=""
+                                draggable={false}
+                                loading="lazy"
+                                decoding="async"
+                                className="size-full object-cover select-none"
+                              />
+                            </span>
+                            <span className="flex min-w-0 flex-col gap-0.5 px-2 py-1.5">
+                              <span
+                                className="truncate text-xs font-medium"
+                                title={entry.name}
+                              >
+                                {entry.name}
+                              </span>
+                              {/* Encoded or not is the only thing here that
+                                  costs money, so it gets the colour. */}
+                              <span
+                                className={cn(
+                                  "flex items-center gap-1 font-mono text-[10px]",
+                                  entry.kind === "reference"
+                                    ? "text-muted-foreground"
+                                    : entry.encodedAt
+                                      ? "text-muted-foreground"
+                                      : "text-primary"
+                                )}
+                              >
+                                {entry.kind === "vibe" &&
+                                  (entry.encodedAt ? (
+                                    <Zap className="size-2.5" aria-hidden />
+                                  ) : (
+                                    <Coins className="size-2.5" aria-hidden />
+                                  ))}
+                                {entry.kind === "reference"
+                                  ? t("referenceLibrary.preciseCost")
+                                  : entry.encodedAt
+                                    ? t("referenceLibrary.encoded")
+                                    : t("referenceLibrary.notEncoded")}
+                              </span>
+                            </span>
+                            {selected && (
+                              <span className="bg-primary text-primary-foreground ring-background absolute top-1.5 right-1.5 flex size-5 items-center justify-center rounded-full font-mono text-[10px] font-semibold tabular-nums ring-2">
+                                {order + 1}
+                              </span>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="w-72 shrink-0 space-y-3 overflow-y-auto border-l py-1 pr-1 pl-3">
+            {editing ? (
+              <>
+                <div className="space-y-1">
+                  <Label htmlFor="reference-name">
+                    {t("referenceLibrary.name")}
+                  </Label>
+                  <Input
+                    id="reference-name"
+                    value={editing.name}
+                    onChange={(event) => patch({ name: event.target.value })}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="reference-group">{t("group.label")}</Label>
+                  <GroupField
+                    id="reference-group"
+                    value={editing.groupName}
+                    options={groupOptions}
+                    onChange={(groupName) => patch({ groupName })}
+                  />
+                </div>
+
+                <LabeledSlider
+                  label={t("reference.strength")}
+                  value={editing.strength}
+                  min={0.01}
+                  max={1}
+                  step={0.01}
+                  onChange={(strength) => patch({ strength })}
+                />
+
+                {editing.kind === "vibe" ? (
+                  <div className="space-y-1.5">
+                    <LabeledSlider
+                      label={t("reference.infoExtracted")}
+                      value={editing.infoExtracted}
+                      min={0.01}
+                      max={1}
+                      step={0.01}
+                      onChange={(infoExtracted) => patch({ infoExtracted })}
+                    />
+                    <p className="text-muted-foreground/80 text-[10px] leading-relaxed">
+                      {t("referenceLibrary.infoExtractedHint")}
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    <div className="space-y-1">
+                      <Label>{t("reference.mode.precise")}</Label>
+                      <div className="flex flex-wrap gap-1">
+                        {REFERENCE_TYPES.map((type: ReferenceType) => (
+                          <Button
+                            key={type}
+                            type="button"
+                            size="xs"
+                            variant={
+                              editing.referenceType === type
+                                ? "secondary"
+                                : "outline"
+                            }
+                            className={cn(
+                              editing.referenceType === type && "border-primary"
+                            )}
+                            onClick={() => patch({ referenceType: type })}
+                          >
+                            {t(
+                              type === "character"
+                                ? "reference.type.character"
+                                : type === "style"
+                                  ? "reference.type.style"
+                                  : "reference.type.characterStyle"
+                            )}
+                          </Button>
+                        ))}
+                      </div>
+                    </div>
+                    <LabeledSlider
+                      label={t("reference.fidelity")}
+                      value={editing.fidelity}
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      onChange={(fidelity) => patch({ fidelity })}
+                    />
+                  </>
+                )}
+
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => {
+                    onSelectedChange(
+                      selectedIds.filter((id) => id !== editing.id)
+                    );
+                    setEditingId(null);
+                    remove.mutate(editing);
+                  }}
+                >
+                  <Trash2 />
+                  {t("action.delete")}
+                </Button>
+              </>
+            ) : (
+              <p className="text-muted-foreground rounded-md border border-dashed p-3 text-center text-[11px] leading-relaxed">
+                {t("referenceLibrary.pickToEdit")}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between border-t pt-3">
+          <span className="text-muted-foreground font-mono text-[11px] tabular-nums">
+            {t("generate.picker.selectedCount", { count: selectedIds.length })}
+          </span>
+          <div className="flex gap-2">
+            {selectedIds.length > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => onSelectedChange([])}
+              >
+                {t("generate.picker.clear")}
+              </Button>
+            )}
+            <Button type="button" size="sm" onClick={() => onOpenChange(false)}>
+              {t("generate.picker.done")}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/reference-library/hooks/queries.ts
+++ b/apps/web/src/features/reference-library/hooks/queries.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  deleteAssetsByPath,
+  deleteCollectionItem,
+  listCollection,
+  saveCollectionItem,
+} from "@/features/library/collections";
+
+import { clearEncodedVibe } from "../lib/api";
+import { normalizeReference, type ReferenceEntry } from "../types/reference";
+
+export const referencesQueryKey = ["collections", "references"] as const;
+
+function sortReferences(entries: ReferenceEntry[]) {
+  return [...entries].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+/**
+ * The saved reference images. Backed by the same local collections API as
+ * characters and styles; the encode itself lives on the server, keyed by id.
+ */
+export function useReferences() {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: referencesQueryKey,
+    queryFn: async () => {
+      const { items } = await listCollection("references");
+      return sortReferences(
+        items.map((item, index) =>
+          normalizeReference(item, `Reference ${index + 1}`)
+        )
+      );
+    },
+  });
+
+  const save = useMutation({
+    mutationFn: async (entry: ReferenceEntry) => {
+      // A changed extraction makes the stored encode wrong, so it goes first.
+      // Leaving it would send a blob that no longer matches the settings.
+      const previous = query.data?.find((item) => item.id === entry.id);
+      if (previous && previous.infoExtracted !== entry.infoExtracted) {
+        await clearEncodedVibe(entry.id).catch(() => undefined);
+        entry = { ...entry, encodedAt: null };
+      }
+      await saveCollectionItem("references", entry);
+      return entry;
+    },
+    onSuccess: (saved) => {
+      queryClient.setQueryData<ReferenceEntry[]>(
+        referencesQueryKey,
+        (current) => {
+          const list = current ?? [];
+          const exists = list.some((item) => item.id === saved.id);
+          return sortReferences(
+            exists
+              ? list.map((item) => (item.id === saved.id ? saved : item))
+              : [saved, ...list]
+          );
+        }
+      );
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: async (entry: ReferenceEntry) => {
+      await clearEncodedVibe(entry.id).catch(() => undefined);
+      if (entry.imagePath) await deleteAssetsByPath([entry.imagePath]);
+      await deleteCollectionItem("references", entry.id);
+    },
+    onSuccess: (_result, entry) => {
+      queryClient.setQueryData<ReferenceEntry[]>(
+        referencesQueryKey,
+        (current) => (current ?? []).filter((item) => item.id !== entry.id)
+      );
+    },
+  });
+
+  return {
+    references: query.data ?? [],
+    isPending: query.isPending,
+    save,
+    remove,
+  };
+}

--- a/apps/web/src/features/reference-library/lib/api.ts
+++ b/apps/web/src/features/reference-library/lib/api.ts
@@ -1,0 +1,39 @@
+import { apiRequest } from "@/lib/api-client";
+
+import type { ReferenceKind } from "../types/reference";
+
+/** What a generation needs from one library entry. */
+export type ResolvedReference = {
+  id: string;
+  kind: ReferenceKind;
+  /** Base64 of the image. Empty for a vibe. */
+  image: string;
+  /** The cached encode. Empty for a precise reference. */
+  encoded: string;
+  referenceType: string;
+  strength: number;
+  fidelity: number;
+};
+
+/**
+ * Asks the server for the entries a run needs.
+ *
+ * Any vibe without a cached encode is encoded here — once, at 2 Anlas — and
+ * kept. Entries that cannot be read are left out rather than failing the call,
+ * so one broken record does not cost a whole run.
+ */
+export async function resolveReferences(ids: string[]) {
+  if (ids.length === 0) return [];
+  const { items } = await apiRequest<{ items: ResolvedReference[] }>(
+    "/references/resolve",
+    { method: "POST", body: { ids } }
+  );
+  return items;
+}
+
+/** Drops the cached encode, so the next use pays for a fresh one. */
+export function clearEncodedVibe(id: string) {
+  return apiRequest<{ ok: boolean }>(`/references/${id}/encoded`, {
+    method: "DELETE",
+  });
+}

--- a/apps/web/src/features/reference-library/types/reference.ts
+++ b/apps/web/src/features/reference-library/types/reference.ts
@@ -1,0 +1,129 @@
+import type { ReferenceType } from "@/features/generate/types/reference";
+
+/**
+ * Which of the two reference kinds an entry is used as. NovelAI cannot take
+ * both in one generation, so an entry commits to one when it is saved.
+ */
+export const REFERENCE_KINDS = ["vibe", "reference"] as const;
+export type ReferenceKind = (typeof REFERENCE_KINDS)[number];
+
+export const REFERENCE_KIND_LABEL_KEYS: Record<ReferenceKind, string> = {
+  vibe: "reference.mode.vibe",
+  reference: "reference.mode.precise",
+};
+
+/**
+ * One saved reference image and the settings it is used with.
+ *
+ * A vibe's encode is the expensive part: 2 Anlas, and the same image with the
+ * same `infoExtracted` always encodes to the same thing. The server keeps that
+ * result on disk, so an entry here is paid for once and free every time after.
+ * `encodedAt` is how the panel knows which is which.
+ */
+export type ReferenceEntry = {
+  id: string;
+  name: string;
+  groupName: string | null;
+  kind: ReferenceKind;
+  /** Asset path of the source image. */
+  imagePath: string;
+  /** When the vibe encode was cached. Null means the next use costs 2 Anlas. */
+  encodedAt: string | null;
+  strength: number;
+  /** Vibe only. Changing it throws the cached encode away. */
+  infoExtracted: number;
+  /** Precise reference only. */
+  referenceType: ReferenceType;
+  /** Precise reference only. */
+  fidelity: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const DEFAULT_VIBE_STRENGTH = 0.6;
+export const DEFAULT_INFO_EXTRACTED = 0.7;
+export const DEFAULT_REFERENCE_STRENGTH = 1;
+export const DEFAULT_FIDELITY = 1;
+
+export function createEmptyReference(
+  kind: ReferenceKind,
+  name: string,
+  imagePath: string
+): ReferenceEntry {
+  const now = new Date().toISOString();
+  return {
+    id: crypto.randomUUID(),
+    name,
+    groupName: null,
+    kind,
+    imagePath,
+    encodedAt: null,
+    strength:
+      kind === "vibe" ? DEFAULT_VIBE_STRENGTH : DEFAULT_REFERENCE_STRENGTH,
+    infoExtracted: DEFAULT_INFO_EXTRACTED,
+    referenceType: "character&style",
+    fidelity: DEFAULT_FIDELITY,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function readString(input: object, key: string): string | undefined {
+  const value: unknown = Reflect.get(input, key);
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(input: object, key: string, fallback: number): number {
+  const value: unknown = Reflect.get(input, key);
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+/** Rebuilds an entry from whatever the store returned. */
+export function normalizeReference(
+  input: unknown,
+  fallbackName: string
+): ReferenceEntry {
+  const base = createEmptyReference("vibe", fallbackName, "");
+  if (!input || typeof input !== "object") return base;
+
+  const kind =
+    readString(input, "kind") === "reference"
+      ? ("reference" as const)
+      : ("vibe" as const);
+  const id = readString(input, "id");
+  const name = readString(input, "name");
+  const groupName = readString(input, "groupName");
+  const encodedAt = readString(input, "encodedAt");
+  const referenceType = readString(input, "referenceType");
+  const createdAt = readString(input, "createdAt");
+  const updatedAt = readString(input, "updatedAt");
+
+  return {
+    id: id && id.length > 0 ? id : base.id,
+    name: name && name.trim().length > 0 ? name.trim() : base.name,
+    groupName:
+      groupName && groupName.trim().length > 0 ? groupName.trim() : null,
+    kind,
+    imagePath: readString(input, "imagePath") ?? "",
+    encodedAt: encodedAt && encodedAt.length > 0 ? encodedAt : null,
+    strength: readNumber(
+      input,
+      "strength",
+      kind === "vibe" ? DEFAULT_VIBE_STRENGTH : DEFAULT_REFERENCE_STRENGTH
+    ),
+    infoExtracted: readNumber(input, "infoExtracted", DEFAULT_INFO_EXTRACTED),
+    referenceType:
+      referenceType === "character" || referenceType === "style"
+        ? referenceType
+        : "character&style",
+    fidelity: readNumber(input, "fidelity", DEFAULT_FIDELITY),
+    createdAt: createdAt && createdAt.length > 0 ? createdAt : base.createdAt,
+    updatedAt: updatedAt && updatedAt.length > 0 ? updatedAt : base.updatedAt,
+  };
+}
+
+export function searchableReferenceText(entry: ReferenceEntry): string {
+  return [entry.name, entry.groupName ?? "", entry.kind]
+    .join(" ")
+    .toLowerCase();
+}

--- a/apps/web/src/i18n/messages/generate.ts
+++ b/apps/web/src/i18n/messages/generate.ts
@@ -128,6 +128,29 @@ const en = {
   "workspace.themeDark": "Dark",
   "workspace.themeSystem": "System",
 
+  "referenceLibrary.title": "Reference library",
+  "referenceLibrary.description":
+    "Saved reference images. A vibe is encoded once and free to reuse after that.",
+  "referenceLibrary.search": "Search by name or group",
+  "referenceLibrary.add": "Add image",
+  "referenceLibrary.newName": "Untitled",
+  "referenceLibrary.empty":
+    "Nothing saved yet. Add an image to reuse it without paying to encode it again.",
+  "referenceLibrary.noMatch": "Nothing matches",
+  "referenceLibrary.name": "Name",
+  "referenceLibrary.encoded": "encoded — free",
+  "referenceLibrary.notEncoded": "2 Anlas on first use",
+  "referenceLibrary.preciseCost": "5 Anlas per image",
+  "referenceLibrary.infoExtractedHint":
+    "Changing this throws the stored encode away, so the next use pays 2 Anlas again.",
+  "referenceLibrary.pickToEdit": "Pick an image to change its settings.",
+  "referenceLibrary.saveError": "Could not save the reference",
+  "referenceLibrary.open": "From the library",
+  "referenceLibrary.picked": "{count} from the library",
+  "referenceLibrary.resolveError":
+    "Could not read the library, so this run goes without it.",
+  "referenceLibrary.dropped": "Left out {count} library reference(s).",
+
   "reference.i2i.title": "Source image (i2i)",
   "reference.i2i.pick": "Choose a source image",
   "reference.i2i.strength": "Change amount",
@@ -299,6 +322,29 @@ const ja: Record<keyof typeof en, string> = {
   "workspace.themeLight": "ライト",
   "workspace.themeDark": "ダーク",
   "workspace.themeSystem": "システム",
+
+  "referenceLibrary.title": "参照ライブラリ",
+  "referenceLibrary.description":
+    "保存した参照画像。バイブは 1 度エンコードすれば、以後は無料で使い回せます。",
+  "referenceLibrary.search": "名前・グループで検索",
+  "referenceLibrary.add": "画像を追加",
+  "referenceLibrary.newName": "無題",
+  "referenceLibrary.empty":
+    "まだありません。画像を追加すると、次からはエンコード代を払わずに使えます。",
+  "referenceLibrary.noMatch": "一致するものがありません",
+  "referenceLibrary.name": "名前",
+  "referenceLibrary.encoded": "エンコード済み — 無料",
+  "referenceLibrary.notEncoded": "初回のみ 2 Anlas",
+  "referenceLibrary.preciseCost": "1 枚 5 Anlas",
+  "referenceLibrary.infoExtractedHint":
+    "変更すると保存済みのエンコードを捨てるので、次の利用でまた 2 Anlas かかります。",
+  "referenceLibrary.pickToEdit": "画像を選ぶと設定を変えられます。",
+  "referenceLibrary.saveError": "参照を保存できませんでした",
+  "referenceLibrary.open": "ライブラリから選ぶ",
+  "referenceLibrary.picked": "ライブラリから {count} 件",
+  "referenceLibrary.resolveError":
+    "ライブラリを読めなかったので、ライブラリ無しで生成します。",
+  "referenceLibrary.dropped": "ライブラリ参照 {count} 件を除きました。",
 
   "reference.i2i.title": "元画像 (i2i)",
   "reference.i2i.pick": "元画像を選ぶ",

--- a/docs/api.md
+++ b/docs/api.md
@@ -110,9 +110,9 @@ API では返さない。web が使っておらず、履歴の全件に付ける
 
 ## コレクション
 
-キャラクター・シチュエーション・スタイルの 3 種をレコード配列として保存する。
+キャラクター・シチュエーション・スタイル・参照ライブラリの 4 種をレコード配列として保存する。
 保存先は設定と同じ configDir を辿り、`<configDir>/collections/<name>.json` に書く。
-`<name>` は `characters` / `situations` / `styles` の 3 つだけで、それ以外は 404。
+`<name>` は `characters` / `situations` / `styles` / `references` の 4 つだけで、それ以外は 404。
 
 | メソッド | パス | 説明 |
 | --- | --- | --- |
@@ -131,6 +131,43 @@ API では返さない。web が使っておらず、履歴の全件に付ける
 1 件差し替える → 全件書き戻す」なので、エディターの自動保存のように重なると、
 どちらも同じスナップショットから始めて後勝ちになり、先の 1 件が黙って消える。
 数ミリ秒の順番待ちと引き換えにこの手の消失をなくしている。
+
+## 参照ライブラリ
+
+バイブ転送・精密参照に使う画像を保存しておき、生成のたびに貼り直さずに使う。
+レコード自体はコレクション `references`、画像はアセットに入るので、CRUD は
+それぞれの汎用エンドポイントを使う。ここにあるのは**エンコード結果の扱い**だけ。
+
+| メソッド | パス | 説明 |
+| --- | --- | --- |
+| `POST` | `/references/resolve` | body `{ ids }` → `{ items: ResolvedReference[] }` |
+| `DELETE` | `/references/:id/encoded` | 保存済みエンコードを捨てる。`{ ok: true }` |
+
+```ts
+type ResolvedReference = {
+  id: string;
+  kind: "vibe" | "reference";
+  image: string;    // base64。精密参照のときだけ入る
+  encoded: string;  // エンコード結果。バイブのときだけ入る
+  referenceType: string;
+  strength: number;
+  fidelity: number;
+};
+```
+
+**バイブのエンコードは 1 回だけ。** `/resolve` は、エンコード結果が
+`<configDir>/encoded-vibes/<id>.txt` に無いバイブだけをその場でエンコードして保存する。
+2 回目以降はファイルを読むだけなので Anlas を消費しない。同じ画像・同じ
+`information_extracted`・同じモデルなら結果は毎回同じなので、取っておけば足りる。
+
+エンコードのモデルは `nai-diffusion-4-5-full` に固定する。エンコード結果はモデル固有で、
+生成時のモデルに合わせると切り替えるたびにキャッシュが無効になり、保存する意味が消える。
+
+`information_extracted` を変えるとキャッシュは捨てられる（web 側が
+`DELETE /references/:id/encoded` を呼ぶ）。中身が変わったのに古い結果を送ると、
+設定と食い違ったものが出る。
+
+解決できなかった id は落として返す。壊れた 1 件で生成 1 回分を失わないため。
 
 ## アセット
 


### PR DESCRIPTION
## 変更内容

Closes #1

参照画像をライブラリとして保存し、**エンコード結果を使い回せる**ようにした。バイブのエンコードは
1 枚 2 Anlas かかるうえ、同じ画像を毎回入れ直すと毎回課金される。ライブラリに入れた画像は初回だけ
払い、以降は無料で使える。

- `<configDir>/collections/references.json` に参照を保存し、エンコード済みの blob は
  `<configDir>/encoded-vibes/<id>.txt` に置く
- `POST /references/resolve` が id を受け取り、キャッシュがあればそれを、無ければエンコードして
  保存してから返す。1 件失敗しても残りは通す（有料の通信なので直列で叩く）
- `DELETE /references/:id/encoded` でキャッシュを捨てる。`infoExtracted` を変えると
  エンコード結果が無効になるので、保存時に自動で捨てる
- エンコードするモデルは `nai-diffusion-4-5-full` に固定。エンコード結果はモデルごとに別物なので、
  固定しないとキャッシュが当たらなくなる
- 生成パネルからライブラリを開いて選べる。タイルのバッジが「2 Anlas on first use」か
  「encoded — free」かを示す。ここがこの画面の主役

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] `bun run check-types`
- [x] `bun run build`
- [x] 実際に動かして確認した（画面の操作と保存されるファイルの中身）

## 備考

- Anlas の見積もりは、ライブラリの参照のうち **未エンコードのものだけ**を上乗せ分に数える
- dev に rebase 済み