### PR TITLE
feat(generate): one reference limit and a stop before spending Anlas

### DIFF
--- a/apps/web/src/features/generate/components/anlas-confirm-dialog.tsx
+++ b/apps/web/src/features/generate/components/anlas-confirm-dialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@nai-desktop-studio/ui/components/alert-dialog";
+
+import { useT } from "@/i18n/provider";
+
+export type ReferenceCost = {
+  /** Charged once for the run, not per image. */
+  encoding: number;
+  /** Vibes past the free ones, charged per image. */
+  vibeSurcharge: number;
+  /** Precise references, charged per image. */
+  precise: number;
+  total: number;
+};
+
+type Props = {
+  open: boolean;
+  /**
+   * The breakdown to show. Null while the estimate is still being fetched —
+   * whether to stop is decided without it, so the dialog can open first and
+   * fill the figures in.
+   */
+  cost: ReferenceCost | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+/**
+ * Last stop before a run spends Anlas on reference images.
+ *
+ * Only the reference surcharge opens this, not the cost of the images
+ * themselves — on a paid plan every generation costs something, and a dialog
+ * in front of all of them would be a click to dismiss rather than a decision.
+ * What is worth a decision is the part that is easy not to notice: encoding is
+ * paid the moment the run starts, whatever comes out of it, and a precise
+ * reference is paid again for every image in the batch.
+ */
+export function AnlasConfirmDialog({ open, cost, onConfirm, onCancel }: Props) {
+  const t = useT();
+
+  const lines: Array<{ key: string; text: string }> = [];
+  if (cost) {
+    if (cost.encoding > 0) {
+      lines.push({
+        key: "encoding",
+        text: t("generate.anlasConfirm.encoding", { count: cost.encoding }),
+      });
+    }
+    if (cost.vibeSurcharge > 0) {
+      lines.push({
+        key: "vibe",
+        text: t("generate.anlasConfirm.vibe", { count: cost.vibeSurcharge }),
+      });
+    }
+    if (cost.precise > 0) {
+      lines.push({
+        key: "precise",
+        text: t("generate.anlasConfirm.precise", { count: cost.precise }),
+      });
+    }
+  }
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("generate.anlasConfirm.title")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {cost
+              ? t("generate.anlasConfirm.description", { count: cost.total })
+              : t("generate.anlasConfirm.pending")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <ul className="text-muted-foreground list-disc space-y-1 pl-5 text-sm">
+          {lines.map((line) => (
+            <li key={line.key}>{line.text}</li>
+          ))}
+        </ul>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>
+            {t("action.cancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {t("generate.anlasConfirm.confirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/features/generate/components/generate-workspace.tsx
+++ b/apps/web/src/features/generate/components/generate-workspace.tsx
@@ -18,6 +18,7 @@ import { INITIAL_FORM } from "../constants";
 import { useAnlasEstimate } from "../hooks/use-anlas-estimate";
 import { useGenerationEngine } from "../hooks/use-generation-engine";
 import { useImageLibrary } from "../hooks/use-image-library";
+import { useReferenceSpend } from "../hooks/use-reference-spend";
 import { supportsReferences } from "../lib/build-request";
 import {
   COMPOSED_PROMPT_FLAGS,
@@ -42,6 +43,7 @@ import type {
 import type { GeneratedImage, GenerationSlot } from "../types/image";
 import { EMPTY_TEMPLATE_SELECTION } from "../types/template";
 import type { TemplateSelection } from "../types/template";
+import { AnlasConfirmDialog } from "./anlas-confirm-dialog";
 import { GeneratePanel } from "./generate-panel";
 import { HistoryFooter } from "./history-footer";
 import { ImageGrid } from "./image-grid";
@@ -119,7 +121,11 @@ export function GenerateWorkspace() {
     mode === "batch"
       ? templateSelection.situationIds.length * form.nSamples
       : form.nSamples;
-  const { anlasText } = useAnlasEstimate(form, plannedImages);
+  const { anlasText, referenceCost } = useAnlasEstimate(form, plannedImages);
+  // Jobs waiting on the Anlas confirmation. Held rather than rebuilt on
+  // confirm so the run is exactly what the figures were quoted for.
+  const [pendingJobs, setPendingJobs] = useState<GenerationJob[] | null>(null);
+  const spendsOnReferences = useReferenceSpend(form);
 
   const update = useCallback((patch: Partial<FormState>) => {
     setForm((current) => {
@@ -236,7 +242,14 @@ export function GenerateWorkspace() {
     setViewedBatch(null);
     setSelectedIds([]);
     const jobs = await buildJobs();
-    if (jobs.length > 0) await engine.generate(jobs);
+    if (jobs.length === 0) return;
+    // Reference images are the part that is spent on top and cannot be taken
+    // back, so a run that pays for them stops here first.
+    if (spendsOnReferences) {
+      setPendingJobs(jobs);
+      return;
+    }
+    await engine.generate(jobs);
   }
 
   const canGenerate =
@@ -434,6 +447,17 @@ export function GenerateWorkspace() {
       />
 
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+
+      <AnlasConfirmDialog
+        open={pendingJobs !== null}
+        cost={referenceCost}
+        onCancel={() => setPendingJobs(null)}
+        onConfirm={() => {
+          const jobs = pendingJobs;
+          setPendingJobs(null);
+          if (jobs) void engine.generate(jobs);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/features/generate/components/reference-settings.tsx
+++ b/apps/web/src/features/generate/components/reference-settings.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import {
+  MAX_CHARACTER_REFERENCES,
+  MAX_VIBE_REFERENCES,
+} from "@nai-desktop-studio/novelai/constants";
 import { Button } from "@nai-desktop-studio/ui/components/button";
 import { cn } from "@nai-desktop-studio/ui/lib/utils";
 import {
@@ -22,11 +26,10 @@ import { useT } from "@/i18n/provider";
 import type { MessageKey } from "@/i18n/messages";
 
 import { readImageFile } from "../lib/image-file";
+import { pickedLibraryReferences } from "../lib/library-references";
 import { supportsReferences } from "../lib/build-request";
 import type { FormState } from "../types/generate";
 import {
-  MAX_REFERENCES,
-  MAX_VIBES,
   REFERENCE_TYPE_LABEL_KEYS,
   REFERENCE_TYPES,
   type AdhocReference,
@@ -311,14 +314,19 @@ type Props = {
 export function ReferenceSettings({ form, update }: Props) {
   const [libraryOpen, setLibraryOpen] = useState(false);
   const { references } = useReferences();
-  // Only the ones that still exist and match the current mode: a reference
-  // saved as a vibe cannot go out in a precise-reference run.
-  const picked = form.libraryReferenceIds.flatMap((id) => {
-    const found = references.find((entry) => entry.id === id);
-    return found && found.kind === form.referenceMode ? [found] : [];
-  });
+  const picked = pickedLibraryReferences(form, references);
   const t = useT();
   const referenceAvailable = supportsReferences(form.model);
+  // One request carries one set of reference images, so what was dropped in
+  // here and what was chosen from the library fill the same allowance.
+  const inUse =
+    (form.referenceMode === "vibe" ? form.vibes : form.references).length +
+    picked.length;
+  const limit =
+    form.referenceMode === "vibe"
+      ? MAX_VIBE_REFERENCES
+      : MAX_CHARACTER_REFERENCES;
+  const atMax = inUse >= limit;
 
   async function handlePickI2i(file: File) {
     const read = await readImageFile(file);
@@ -473,12 +481,8 @@ export function ReferenceSettings({ form, update }: Props) {
               </ul>
             )}
             <AddImageButton
-              label={
-                form.vibes.length >= MAX_VIBES
-                  ? t("reference.atMax")
-                  : t("reference.vibe.add")
-              }
-              disabled={form.vibes.length >= MAX_VIBES}
+              label={atMax ? t("reference.atMax") : t("reference.vibe.add")}
+              disabled={atMax}
               onPick={handleAddVibe}
             />
           </div>
@@ -505,14 +509,8 @@ export function ReferenceSettings({ form, update }: Props) {
               </ul>
             )}
             <AddImageButton
-              label={
-                form.references.length >= MAX_REFERENCES
-                  ? t("reference.atMax")
-                  : t("reference.precise.add")
-              }
-              disabled={
-                !referenceAvailable || form.references.length >= MAX_REFERENCES
-              }
+              label={atMax ? t("reference.atMax") : t("reference.precise.add")}
+              disabled={!referenceAvailable || atMax}
               onPick={handleAddReference}
             />
           </div>
@@ -583,6 +581,7 @@ export function ReferenceSettings({ form, update }: Props) {
         open={libraryOpen}
         onOpenChange={setLibraryOpen}
         kind={form.referenceMode}
+        remaining={Math.max(limit - inUse, 0)}
         selectedIds={form.libraryReferenceIds}
         onSelectedChange={(libraryReferenceIds) =>
           update({ libraryReferenceIds })

--- a/apps/web/src/features/generate/hooks/use-anlas-estimate.ts
+++ b/apps/web/src/features/generate/hooks/use-anlas-estimate.ts
@@ -107,7 +107,10 @@ export function useAnlasEstimate(form: FormState, imageCount?: number) {
   });
 
   // In queue mode each image is its own request, so the per-request cost repeats
-  // for every image. Vibe encoding is charged once for the batch, not per image.
+  // for every image; in alternate mode the figure already covers the batch.
+  // Vibe encoding is the exception either way: charged once, not per image.
+  const repeats = deferred.mode === "alternate" ? 1 : deferred.nSamples;
+
   const total = query.data
     ? deferred.mode === "alternate"
       ? query.data.total_anlas
@@ -116,6 +119,25 @@ export function useAnlasEstimate(form: FormState, imageCount?: number) {
           query.data.vibe_reference_anlas) *
           deferred.nSamples +
         query.data.vibe_encoding_anlas
+    : null;
+
+  /**
+   * What the reference images add on top of the images themselves.
+   *
+   * Kept apart from the total because it is the part worth stopping for: the
+   * base cost is what the person asked for, while this is spent on top and,
+   * for encoding, spent whether or not the result is any good.
+   */
+  const encoding = query.data?.vibe_encoding_anlas ?? 0;
+  const vibeSurcharge = (query.data?.vibe_reference_anlas ?? 0) * repeats;
+  const precise = (query.data?.character_reference_anlas ?? 0) * repeats;
+  const referenceCost = query.data
+    ? {
+        encoding,
+        vibeSurcharge,
+        precise,
+        total: encoding + vibeSurcharge + precise,
+      }
     : null;
 
   // "0 Anlas" reads too much like a real cost at a glance, so say it is free.
@@ -128,5 +150,5 @@ export function useAnlasEstimate(form: FormState, imageCount?: number) {
         ? t("generate.free")
         : t("unit.anlas", { count: total.toLocaleString() });
 
-  return { anlasText, estimate: query.data ?? null };
+  return { anlasText, estimate: query.data ?? null, referenceCost };
 }

--- a/apps/web/src/features/generate/hooks/use-reference-spend.ts
+++ b/apps/web/src/features/generate/hooks/use-reference-spend.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { VIBE_FREE_COUNT } from "@nai-desktop-studio/novelai/constants";
+
+import { useReferences } from "@/features/reference-library/hooks/queries";
+
+import { pickedLibraryReferences } from "../lib/library-references";
+import type { FormState } from "../types/generate";
+
+/**
+ * Whether this run will spend Anlas on its reference images.
+ *
+ * Worked out from the panel rather than from the Anlas estimate. The estimate
+ * is deferred and then fetched, so in the moment after an image is dropped in
+ * it still describes the run before it — and a stale "costs nothing" would
+ * spend the money without asking. What the panel holds is always current.
+ */
+export function useReferenceSpend(form: FormState): boolean {
+  const { references } = useReferences();
+  const picked = pickedLibraryReferences(form, references);
+
+  // Precise references are charged for every image, every run. Nothing about
+  // them is ever free.
+  if (form.referenceMode === "reference") {
+    return form.references.length + picked.length > 0;
+  }
+
+  const vibeCount = form.vibes.length + picked.length;
+  if (vibeCount === 0) return false;
+
+  // An image dropped straight into the panel is encoded again on every run;
+  // one from the library keeps its encode after the first time.
+  const uncached =
+    form.vibes.length +
+    picked.filter((entry) => entry.encodedAt === null).length;
+
+  return uncached > 0 || vibeCount > VIBE_FREE_COUNT;
+}

--- a/apps/web/src/features/generate/lib/library-references.ts
+++ b/apps/web/src/features/generate/lib/library-references.ts
@@ -1,0 +1,21 @@
+import type { ReferenceEntry } from "@/features/reference-library/types/reference";
+
+import type { FormState } from "../types/generate";
+
+/**
+ * The library entries this run actually carries.
+ *
+ * Two things can make a chosen id drop out: the entry was deleted from the
+ * library, or it is of the other kind — a reference saved as a vibe cannot go
+ * out in a precise-reference run. Both are silent, so anything that counts or
+ * prices the run has to count what is left rather than the chosen ids.
+ */
+export function pickedLibraryReferences(
+  form: Pick<FormState, "libraryReferenceIds" | "referenceMode">,
+  library: ReferenceEntry[]
+): ReferenceEntry[] {
+  return form.libraryReferenceIds.flatMap((id) => {
+    const found = library.find((entry) => entry.id === id);
+    return found && found.kind === form.referenceMode ? [found] : [];
+  });
+}

--- a/apps/web/src/features/generate/lib/style-references.ts
+++ b/apps/web/src/features/generate/lib/style-references.ts
@@ -1,16 +1,21 @@
+import {
+  MAX_CHARACTER_REFERENCES,
+  MAX_VIBE_REFERENCES,
+} from "@nai-desktop-studio/novelai/constants";
+
 import { loadAssetAsBase64 } from "@/features/library/asset-image";
 import { assetUrl } from "@/features/library/collections";
 import type { Style } from "@/features/styles/types/style";
 
-import { MAX_REFERENCES, MAX_VIBES } from "../types/reference";
 import type { AdhocReference, AdhocVibe } from "../types/reference";
 
 /**
  * Turns a style's stored images into form entries. The style keeps paths, but a
  * generation sends bytes, so each image is fetched back here.
  *
- * The panel holds fewer images than a style may, so the extras are dropped
- * rather than sent — the caller reports how many were kept.
+ * A style cannot hold more than a request may carry, so nothing is normally
+ * dropped here; the slice only guards a style saved before the limit was what
+ * it is now. The caller reports anything that did not make it.
  */
 export async function loadStyleReferenceImages(style: Style) {
   const vibes = [...style.vibes].sort((a, b) => a.sortOrder - b.sortOrder);
@@ -20,7 +25,7 @@ export async function loadStyleReferenceImages(style: Style) {
 
   const [loadedVibes, loadedReferences] = await Promise.all([
     Promise.all(
-      vibes.slice(0, MAX_VIBES).map(
+      vibes.slice(0, MAX_VIBE_REFERENCES).map(
         async (vibe): Promise<AdhocVibe> => ({
           id: vibe.id,
           previewUrl: assetUrl(vibe.imagePath),
@@ -31,7 +36,7 @@ export async function loadStyleReferenceImages(style: Style) {
       )
     ),
     Promise.all(
-      references.slice(0, MAX_REFERENCES).map(
+      references.slice(0, MAX_CHARACTER_REFERENCES).map(
         async (reference): Promise<AdhocReference> => ({
           id: reference.id,
           previewUrl: assetUrl(reference.imagePath),

--- a/apps/web/src/features/generate/types/reference.ts
+++ b/apps/web/src/features/generate/types/reference.ts
@@ -47,10 +47,3 @@ export type I2iSource = {
   strength: number;
   noise: number;
 };
-
-/** The first 4 vibes are free to add; from the 5th on it's 2 Anlas each. */
-export const VIBE_FREE_COUNT = 4;
-export const VIBE_EXTRA_ANLAS = 2;
-export const CHARACTER_REFERENCE_EXTRA_ANLAS = 5;
-export const MAX_VIBES = 8;
-export const MAX_REFERENCES = 4;

--- a/apps/web/src/features/reference-library/components/reference-picker-dialog.tsx
+++ b/apps/web/src/features/reference-library/components/reference-picker-dialog.tsx
@@ -38,6 +38,11 @@ type Props = {
   kind: ReferenceKind;
   selectedIds: string[];
   onSelectedChange: (ids: string[]) => void;
+  /**
+   * How many more images this run has room for. A request is capped whatever
+   * the images came from, so what the panel already holds counts against this.
+   */
+  remaining: number;
 };
 
 /**
@@ -54,6 +59,7 @@ export function ReferencePickerDialog({
   kind,
   selectedIds,
   onSelectedChange,
+  remaining,
 }: Props) {
   const t = useT();
   const { references, save, remove } = useReferences();
@@ -129,11 +135,17 @@ export function ReferencePickerDialog({
   }
 
   function toggle(id: string) {
-    onSelectedChange(
-      selectedIds.includes(id)
-        ? selectedIds.filter((item) => item !== id)
-        : [...selectedIds, id]
-    );
+    if (selectedIds.includes(id)) {
+      onSelectedChange(selectedIds.filter((item) => item !== id));
+      setEditingId(id);
+      return;
+    }
+    // Deselecting is always allowed; only adding can run past the limit.
+    if (remaining <= 0) {
+      toast.error(t("referenceLibrary.atMax"));
+      return;
+    }
+    onSelectedChange([...selectedIds, id]);
     setEditingId(id);
   }
 

--- a/apps/web/src/features/styles/components/style-reference-manager.tsx
+++ b/apps/web/src/features/styles/components/style-reference-manager.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MAX_CHARACTER_REFERENCES } from "@nai-desktop-studio/novelai/constants";
 import {
   Select,
   SelectContent,
@@ -14,11 +15,7 @@ import { LabeledSlider } from "@/components/labeled-slider";
 import { useT } from "@/i18n/provider";
 import type { MessageKey } from "@/i18n/messages";
 
-import {
-  MAX_STYLE_REFERENCES,
-  STYLE_REFERENCE_TYPES,
-  type StyleReferenceType,
-} from "../types/style";
+import { STYLE_REFERENCE_TYPES, type StyleReferenceType } from "../types/style";
 import {
   AddImageButton,
   imageSrc,
@@ -128,7 +125,7 @@ export function StyleReferenceManager({
   blocked,
 }: Props) {
   const t = useT();
-  const atMax = references.length >= MAX_STYLE_REFERENCES;
+  const atMax = references.length >= MAX_CHARACTER_REFERENCES;
 
   async function handleAdd(file: File) {
     const read = await readPendingImage(file);
@@ -171,7 +168,7 @@ export function StyleReferenceManager({
       <div className="space-y-1">
         <h4 className="text-sm font-medium">{t("styles.references.title")}</h4>
         <p className="text-muted-foreground text-xs leading-tight">
-          {t("styles.references.hint", { max: MAX_STYLE_REFERENCES })}
+          {t("styles.references.hint", { max: MAX_CHARACTER_REFERENCES })}
         </p>
         {blocked && (
           <p className="text-xs leading-tight text-amber-600">

--- a/apps/web/src/features/styles/components/style-vibe-manager.tsx
+++ b/apps/web/src/features/styles/components/style-vibe-manager.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { MAX_VIBE_REFERENCES } from "@nai-desktop-studio/novelai/constants";
 import { useState } from "react";
 import { toast } from "sonner";
 
 import { LabeledSlider } from "@/components/labeled-slider";
 import { useT } from "@/i18n/provider";
 
-import { MAX_STYLE_VIBES } from "../types/style";
 import {
   AddImageButton,
   imageSrc,
@@ -80,7 +80,7 @@ type Props = {
 
 export function StyleVibeManager({ vibes, onChange, blocked }: Props) {
   const t = useT();
-  const atMax = vibes.length >= MAX_STYLE_VIBES;
+  const atMax = vibes.length >= MAX_VIBE_REFERENCES;
 
   async function handleAdd(file: File) {
     const read = await readPendingImage(file);
@@ -120,7 +120,7 @@ export function StyleVibeManager({ vibes, onChange, blocked }: Props) {
       <div className="space-y-1">
         <h4 className="text-sm font-medium">{t("styles.vibes.title")}</h4>
         <p className="text-muted-foreground text-xs leading-tight">
-          {t("styles.vibes.hint", { max: MAX_STYLE_VIBES })}
+          {t("styles.vibes.hint", { max: MAX_VIBE_REFERENCES })}
         </p>
         <p className="text-muted-foreground text-xs leading-tight">
           {t("styles.vibes.encodeNote")}

--- a/apps/web/src/features/styles/types/style.ts
+++ b/apps/web/src/features/styles/types/style.ts
@@ -39,9 +39,6 @@ export type StyleGenerationParams = {
   noiseSchedule: StyleNoiseSchedule | null;
 };
 
-export const MAX_STYLE_VIBES = 16;
-export const MAX_STYLE_REFERENCES = 6;
-
 export const STYLE_REFERENCE_TYPES = [
   "character",
   "style",

--- a/apps/web/src/i18n/messages/generate.ts
+++ b/apps/web/src/i18n/messages/generate.ts
@@ -150,6 +150,20 @@ const en = {
   "referenceLibrary.resolveError":
     "Could not read the library, so this run goes without it.",
   "referenceLibrary.dropped": "Left out {count} library reference(s).",
+  "referenceLibrary.atMax":
+    "This run already carries as many reference images as it can.",
+
+  "generate.anlasConfirm.title": "This run spends Anlas",
+  "generate.anlasConfirm.description":
+    "The reference images add about {count} Anlas on top of the images themselves. Go ahead?",
+  "generate.anlasConfirm.pending": "Working out what this run costs\u2026",
+  "generate.anlasConfirm.encoding":
+    "Encoding the vibe images: {count} Anlas, once — reused free after that",
+  "generate.anlasConfirm.vibe":
+    "Vibes past the free four: {count} Anlas across the run",
+  "generate.anlasConfirm.precise":
+    "Precise references: {count} Anlas across the run",
+  "generate.anlasConfirm.confirm": "Generate",
 
   "reference.i2i.title": "Source image (i2i)",
   "reference.i2i.pick": "Choose a source image",
@@ -345,6 +359,17 @@ const ja: Record<keyof typeof en, string> = {
   "referenceLibrary.resolveError":
     "ライブラリを読めなかったので、ライブラリ無しで生成します。",
   "referenceLibrary.dropped": "ライブラリ参照 {count} 件を除きました。",
+  "referenceLibrary.atMax": "この生成で使える参照画像の上限に達しています。",
+
+  "generate.anlasConfirm.title": "Anlas を消費します",
+  "generate.anlasConfirm.description":
+    "参照画像の分として、画像そのものの費用に約 {count} Anlas が上乗せされます。続けますか。",
+  "generate.anlasConfirm.pending": "この生成の費用を計算しています…",
+  "generate.anlasConfirm.encoding":
+    "バイブのエンコード: {count} Anlas（初回のみ。以降は無料で使い回せます）",
+  "generate.anlasConfirm.vibe": "無料枠 4 枚を超えるバイブ: 合計 {count} Anlas",
+  "generate.anlasConfirm.precise": "精密参照: 合計 {count} Anlas",
+  "generate.anlasConfirm.confirm": "生成する",
 
   "reference.i2i.title": "元画像 (i2i)",
   "reference.i2i.pick": "元画像を選ぶ",

--- a/packages/novelai/src/constants.ts
+++ b/packages/novelai/src/constants.ts
@@ -103,6 +103,17 @@ export const CHARACTER_REFERENCE_EXTRA_ANLAS = 5;
 // The first 4 vibes are free. Each vibe past the 4th costs VIBE_EXTRA_ANLAS.
 export const VIBE_FREE_COUNT = 4;
 
+/**
+ * How many reference images one request may carry.
+ *
+ * A style and a single generation are bounded by the same request, so the
+ * numbers live here rather than once per screen. They were duplicated before,
+ * with the generate panel capped at half the style's figure, which silently
+ * dropped the extra images on the way to a request.
+ */
+export const MAX_VIBE_REFERENCES = 16;
+export const MAX_CHARACTER_REFERENCES = 6;
+
 export const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 export const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
 export const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;


### PR DESCRIPTION
## 変更内容

Closes #6

**1. 枚数の上限が 2 か所で食い違っていた**

| | 生成パネル | 絵柄 |
| --- | --- | --- |
| バイブ | 8 | 16 |
| 精密参照 | 4 | 6 |

同じ「1 リクエストに載る枚数」なのに別々に定義されていた。実害として、バイブを 16 個登録した
絵柄で生成すると **8 個が黙って落ちていた**。`packages/novelai/src/constants.ts` に 1 か所だけ置き、
絵柄・生成・ライブラリが同じ値を見るようにした。使われていない重複定数も消した。

**2. ライブラリから選んだ参照が上限に数えられていなかった**

追加ボタンは `form.vibes.length` だけを見ていたので、上限まで単発で足したうえにライブラリからも
選べた。合計で判定し、ピッカーにも残り枠を渡して選択を止める。

**3. Anlas を使う生成の前に確認が無かった**

内訳付きの確認ダイアログを追加した。

止めるかどうかの判定は**見積もり API ではなくフォームから同期的に**行う。見積もりは
`useDeferredValue` 越しの非同期なので、画像を足した直後に生成を押すと古い「0 Anlas」で素通りし、
確認なしで Anlas を使ってしまう。金額の表示だけ見積もりから取る。エンコード済みライブラリ
バイブだけの生成は無料なので止めない。

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] `bun run check-types`
- [x] `bun run build`
- [x] **見積もり API を直接叩いて出し分けの根拠を確認**

  | 条件 | encode | 追加分 | 精密参照 | ダイアログ |
  | --- | --- | --- | --- | --- |
  | 参照なし | 0 | 0 | 0 | 出さない |
  | 新規バイブ 1 枚 | 2 | 0 | 0 | 出す |
  | エンコード済み 1 枚 | 0 | 0 | 0 | 出さない |
  | バイブ 6 枚（4 枚が新規） | 8 | 4 | 0 | 出す |
  | 精密参照 2 枚 | 0 | 0 | 10 | 出す |

- [x] **ブラウザで実際に確認** — バイブ追加 → 生成 → ダイアログが内訳付きで出る →
      キャンセルで閉じる。コンソールエラー 0、Anlas 消費なし

## 備考

- 前提: #10。dev に rebase 済みなので、#10 が入れば差分はこの PR のコミット 1 本だけになる
- **確認をスキップする側（参照なしの通常生成）は未検証**。実際に生成が走ってしまうため