### PR TITLE
fix(desktop): keep the bundle payload out of lint and format

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -11,6 +11,8 @@
     "dist",
     "build",
     "tag-index.json",
-    "**/routeTree.gen.ts"
+    "**/routeTree.gen.ts",
+    "apps/desktop/src-tauri/resources",
+    "apps/desktop/src-tauri/binaries"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -63,6 +63,8 @@
     "build",
     "*.config.js",
     "*.config.ts",
-    "**/routeTree.gen.ts"
+    "**/routeTree.gen.ts",
+    "apps/desktop/src-tauri/resources",
+    "apps/desktop/src-tauri/binaries"
   ]
 }


### PR DESCRIPTION
## 変更内容

Closes #7

`bun run --cwd apps/desktop payload` を一度実行すると、以降 `bun run check` が数百件のエラーで
落ち、`git push` も pre-push フックで止まる。

payload スクリプトが `apps/desktop/src-tauri/resources/` に server のバンドル（minify 済みの
1 ファイル）と `node_modules` を書き出すため。`.gitignore` 済みなので **CI では再現しない**が、
oxlint / oxfmt の `ignorePatterns` には入っていないのでローカルでは走査対象になる。

デスクトップ版を一度でもビルドした人は、以降ずっと `bun run check` が使えなくなっていた。

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] `bun run check-types`
- [x] `bun run build`
- [x] **payload を生成した状態で再現・修正を確認した。** 修正前は数百件のエラー、修正後は通る

## 備考

#2 の積み残し。PR #4 のマージ後に見つけたので別 PR になった。