### PR TITLE
ci(issues): close linked issues when a pull request merges into dev

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,0 +1,68 @@
+name: Close linked issues
+
+# GitHub only acts on "Closes #12" when the pull request lands on the default
+# branch. Everything here lands on dev, so the keyword draws the link and
+# nothing else happens — PR #4 and #5 both said Closes and left their issues
+# open. This does the closing.
+#
+# pull_request_target rather than pull_request: the workflow then runs from
+# dev's copy of this file with a token that may write, instead of from the
+# branch being merged. Nothing from the pull request is checked out or run —
+# only its body is read, and it is passed through the environment rather than
+# into the shell, because a body can contain anything.
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  issues: write
+
+jobs:
+  close:
+    name: Close what the pull request said it closes
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close the linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # The keyword must start a word, so "encloses #5" is not a closing
+          # reference. A cross-repo "owner/repo#9" has no "#" straight after
+          # the keyword and is left alone: this only closes its own issues.
+          numbers=$(printf '%s' "$BODY" \
+            | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' | sort -un || true)
+
+          if [ -z "$numbers" ]; then
+            echo "No closing keyword in #$PR_NUMBER." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          for n in $numbers; do
+            # Issues and pull requests share one numbering, and a body may well
+            # point at another pull request. Only issues are closed here.
+            if ! meta=$(gh api "repos/$REPO/issues/$n" 2>/dev/null); then
+              echo "- #$n: no such issue" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            if [ "$(printf '%s' "$meta" | jq -r '.pull_request // empty')" != "" ]; then
+              echo "- #$n: a pull request, left alone" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            if [ "$(printf '%s' "$meta" | jq -r .state)" = "closed" ]; then
+              echo "- #$n: already closed" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            gh issue close "$n" --repo "$REPO" --reason completed \
+              --comment "Closed by #$PR_NUMBER ($PR_TITLE), merged into dev."
+            echo "- #$n: closed" >> "$GITHUB_STEP_SUMMARY"
+          done


### PR DESCRIPTION
## 変更内容

Closes #15

`dev` にマージされた PR の本文から `Closes #N` を拾い、その Issue を閉じるワークフローを足した。

GitHub の自動クローズは**デフォルトブランチにマージされたときだけ**動く。このリポジトリの既定は
`main` で作業はすべて `dev` 宛てなので、`Closes #N` は紐付けの表示にしかなっていなかった。

`pull_request` ではなく `pull_request_target` を使う。ワークフローがマージ対象のブランチ側では
なく `dev` 側のコピーから、書き込み可能なトークンで動く。**PR のコードは checkout も実行もせず、
本文だけを読む。** 本文は何でも書ける入力なので、`run:` に直接展開せず env 経由で渡している。

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] **キーワードの解析を実データで確認**

  | 本文 | 拾う番号 |
  | --- | --- |
  | `Closes #1` | 1 |
  | `fixes #12 and Resolves #34` | 12, 34 |
  | `Fixed #7, Closed #8` | 7, 8 |
  | `Closes #5 and closes #5` | 5（重複を除く） |
  | `encloses #5` | なし（語の途中） |
  | `unfixed #6` | なし |
  | `Closes owner/other#9` | なし（他リポジトリは対象外） |
  | キーワード無し / 空 | なし |

- [x] **ワークフローの `run:` をそのまま実リポジトリに対して実行し、全分岐を確認**

  | 入力 | 結果 |
  | --- | --- |
  | 開いている Issue | close される |
  | 既に閉じている Issue | `already closed` で素通り |
  | PR の番号 | `a pull request, left alone` |
  | 存在しない番号 | `no such issue` |
  | キーワード無し | 何もせず終了 |
