### PR TITLE
feat(references): give reference images their own file-based store

### DIFF
--- a/apps/server/src/assets.ts
+++ b/apps/server/src/assets.ts
@@ -39,15 +39,6 @@ async function findAssetPath(id: string): Promise<string | null> {
   return null;
 }
 
-/** The bytes behind an `/assets/<id>/file` path, for server-side use. */
-export async function readAssetBase64(path: string): Promise<string | null> {
-  const id = /\/assets\/([^/]+)/.exec(path)?.[1];
-  if (!id) return null;
-  const file = await findAssetPath(id);
-  if (!file) return null;
-  return Buffer.from(await Bun.file(file).arrayBuffer()).toString("base64");
-}
-
 const postBodySchema = z.object({
   imageBase64: z.string().min(1),
   contentType: z.string().min(1),

--- a/apps/server/src/collections.ts
+++ b/apps/server/src/collections.ts
@@ -3,12 +3,7 @@ import { join } from "node:path";
 import { Hono } from "hono";
 import { configDir } from "./paths";
 
-const COLLECTION_NAMES = [
-  "characters",
-  "situations",
-  "styles",
-  "references",
-] as const;
+const COLLECTION_NAMES = ["characters", "situations", "styles"] as const;
 type CollectionName = (typeof COLLECTION_NAMES)[number];
 
 function isCollectionName(value: string): value is CollectionName {
@@ -140,26 +135,6 @@ function byUpdatedAtDesc(a: CollectionRecord, b: CollectionRecord): number {
   const ua = typeof a.updatedAt === "string" ? a.updatedAt : "";
   const ub = typeof b.updatedAt === "string" ? b.updatedAt : "";
   return ub.localeCompare(ua);
-}
-
-/** Reads a collection from inside the server. The web owns the shape, so the
- * caller narrows it. */
-export async function readCollection(
-  name: CollectionName
-): Promise<CollectionRecord[]> {
-  return load(name);
-}
-
-/** Replaces one record in place. Used to write back a cached encode. */
-export async function patchCollectionRecord(
-  name: CollectionName,
-  id: string,
-  patch: Record<string, unknown>
-): Promise<void> {
-  const current = await load(name);
-  const found = current.find((record) => record.id === id);
-  if (!found) return;
-  await upsert(name, { ...found, ...patch, id });
 }
 
 export const collectionsRouter = new Hono()

--- a/apps/server/src/references.ts
+++ b/apps/server/src/references.ts
@@ -1,4 +1,4 @@
-import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
@@ -6,8 +6,6 @@ import { z } from "zod";
 import { env } from "@nai-desktop-studio/env/server";
 import { createNovelAIClient } from "@nai-desktop-studio/novelai";
 import type { EncodeVibeBody } from "@nai-desktop-studio/novelai";
-import { readAssetBase64 } from "./assets";
-import { patchCollectionRecord, readCollection } from "./collections";
 import { onInvalid } from "./http";
 import { configDir } from "./paths";
 import { getApiKey } from "./settings";
@@ -22,14 +20,159 @@ import { getApiKey } from "./settings";
  */
 const ENCODE_MODEL = "nai-diffusion-4-5-full";
 
+/**
+ * One reference is one directory:
+ *
+ *     <configDir>/references/<id>/
+ *     ├── reference.json
+ *     ├── image.png
+ *     └── encoded.txt      (a vibe, after its first paid encode)
+ *
+ * Everything about an entry is in one place, so creating it is one write and
+ * deleting it is one removal. The three parts used to live in three trees —
+ * a row in one big collections file, a file under assets/, a file under
+ * encoded-vibes/ — which left the browser to keep them in step across three
+ * requests, and left an interrupted delete as an image nobody references or an
+ * encode nobody owns.
+ */
+function referencesDir(): string {
+  return join(configDir(), "references");
+}
+
+// The id lands in a filesystem path, so restrict it rather than trust it.
 const ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
-function encodedDir(): string {
-  return join(configDir(), "encoded-vibes");
+function entryDir(id: string): string {
+  return join(referencesDir(), id);
+}
+
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/jpeg": "jpg",
+};
+
+const TYPE_BY_EXT: Record<string, string> = {
+  png: "image/png",
+  webp: "image/webp",
+  jpg: "image/jpeg",
+};
+
+/** Decoded image cap, matching the assets endpoint. */
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+/** What is written to `reference.json`. */
+type StoredReference = {
+  id: string;
+  name: string;
+  groupName: string | null;
+  kind: "vibe" | "reference";
+  strength: number;
+  infoExtracted: number;
+  referenceType: string;
+  fidelity: number;
+  /** When the encode was cached. Null means the next use costs 2 Anlas. */
+  encodedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function metaPath(id: string): string {
+  return join(entryDir(id), "reference.json");
 }
 
 function encodedPath(id: string): string {
-  return join(encodedDir(), `${id}.txt`);
+  return join(entryDir(id), "encoded.txt");
+}
+
+/** The stored image, found by probing the extensions that can be written. */
+async function imagePath(id: string): Promise<string | null> {
+  if (!ID_PATTERN.test(id)) return null;
+  for (const ext of Object.keys(TYPE_BY_EXT)) {
+    const candidate = join(entryDir(id), `image.${ext}`);
+    if (await Bun.file(candidate).exists()) return candidate;
+  }
+  return null;
+}
+
+/** Write through a temporary file, so a crash cannot leave a torn one. */
+async function writeAtomic(
+  target: string,
+  data: string | Uint8Array
+): Promise<void> {
+  const tmp = `${target}.${crypto.randomUUID()}.tmp`;
+  await writeFile(tmp, data);
+  await rename(tmp, target).catch(async (error: unknown) => {
+    await rm(tmp, { force: true });
+    throw error;
+  });
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Rebuild an entry from its file. A field that is missing or the wrong type
+ * falls back rather than failing: a library that will not open because one
+ * record was hand-edited is worse than one that opens with a default.
+ */
+function normalize(input: unknown, id: string): StoredReference {
+  const record = (input ?? {}) as Record<string, unknown>;
+  const kind = record.kind === "reference" ? "reference" : "vibe";
+  const referenceType = readString(record.referenceType);
+  const now = new Date().toISOString();
+
+  return {
+    id,
+    name: readString(record.name) ?? id,
+    groupName: readString(record.groupName),
+    kind,
+    strength: readNumber(record.strength, kind === "vibe" ? 0.6 : 1),
+    infoExtracted: readNumber(record.infoExtracted, 0.7),
+    referenceType:
+      referenceType === "character" || referenceType === "style"
+        ? referenceType
+        : "character&style",
+    fidelity: readNumber(record.fidelity, 1),
+    encodedAt: readString(record.encodedAt),
+    createdAt: readString(record.createdAt) ?? now,
+    updatedAt: readString(record.updatedAt) ?? now,
+  };
+}
+
+async function readEntry(id: string): Promise<StoredReference | null> {
+  if (!ID_PATTERN.test(id)) return null;
+  const file = Bun.file(metaPath(id));
+  if (!(await file.exists())) return null;
+  try {
+    return normalize(await file.json(), id);
+  } catch {
+    return null;
+  }
+}
+
+async function writeEntry(entry: StoredReference): Promise<void> {
+  await mkdir(entryDir(entry.id), { recursive: true });
+  await writeAtomic(metaPath(entry.id), `${JSON.stringify(entry, null, 2)}\n`);
+}
+
+async function listEntries(): Promise<StoredReference[]> {
+  let names: string[];
+  try {
+    names = await readdir(referencesDir());
+  } catch {
+    // Nothing saved yet.
+    return [];
+  }
+  const entries = await Promise.all(names.map((name) => readEntry(name)));
+  return entries
+    .filter((entry): entry is StoredReference => entry !== null)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 }
 
 async function readEncoded(id: string): Promise<string | null> {
@@ -37,35 +180,9 @@ async function readEncoded(id: string): Promise<string | null> {
   return (await file.exists()) ? file.text() : null;
 }
 
-async function writeEncoded(id: string, encoded: string): Promise<void> {
-  await mkdir(encodedDir(), { recursive: true });
-  const target = encodedPath(id);
-  const tmp = `${target}.${crypto.randomUUID()}.tmp`;
-  await writeFile(tmp, encoded);
-  await rename(tmp, target).catch(async (error: unknown) => {
-    await rm(tmp, { force: true });
-    throw error;
-  });
-}
-
 export async function deleteEncoded(id: string): Promise<void> {
+  if (!ID_PATTERN.test(id)) return;
   await rm(encodedPath(id), { force: true }).catch(() => undefined);
-}
-
-/** One library entry, as far as this endpoint needs to understand it. */
-type ReferenceRecord = {
-  id: string;
-  kind?: unknown;
-  imagePath?: unknown;
-  strength?: unknown;
-  infoExtracted?: unknown;
-  referenceType?: unknown;
-  fidelity?: unknown;
-  encodedAt?: unknown;
-};
-
-function readNumber(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
 export type ResolvedReference = {
@@ -80,86 +197,155 @@ export type ResolvedReference = {
   fidelity: number;
 };
 
-const resolveBodySchema = z.object({
-  ids: z.array(z.string().min(1)).min(1).max(32),
-});
-
 /**
  * Turns library ids into what a generation request needs.
  *
- * A vibe is encoded here, once, and the result is kept on disk. Every later
- * generation reads the file instead of spending 2 Anlas again — which is the
+ * A vibe is encoded here, once, and the result is kept beside it. Every later
+ * generation reads that file instead of spending 2 Anlas again — which is the
  * reason the library exists. A precise reference is sent as the image itself,
  * so it only has to be read back.
  */
 async function resolveOne(
-  record: ReferenceRecord,
+  entry: StoredReference,
   encodeVibe: (request: EncodeVibeBody) => Promise<string>
 ): Promise<ResolvedReference | null> {
-  const kind = record.kind === "reference" ? "reference" : "vibe";
-  const imagePath =
-    typeof record.imagePath === "string" ? record.imagePath : "";
-  const strength = readNumber(record.strength, kind === "vibe" ? 0.6 : 1);
-  const fidelity = readNumber(record.fidelity, 1);
-  const referenceType =
-    typeof record.referenceType === "string"
-      ? record.referenceType
-      : "character&style";
+  const source = await imagePath(entry.id);
+  if (!source) return null;
 
-  if (kind === "reference") {
-    const image = await readAssetBase64(imagePath);
-    if (!image) return null;
+  const common = {
+    id: entry.id,
+    kind: entry.kind,
+    referenceType: entry.referenceType,
+    strength: entry.strength,
+    fidelity: entry.fidelity,
+  };
+
+  if (entry.kind === "reference") {
+    const bytes = await Bun.file(source).arrayBuffer();
     return {
-      id: record.id,
-      kind,
-      image,
+      ...common,
+      image: Buffer.from(bytes).toString("base64"),
       encoded: "",
-      referenceType,
-      strength,
-      fidelity,
     };
   }
 
-  const cached = await readEncoded(record.id);
-  if (cached) {
-    return {
-      id: record.id,
-      kind,
-      image: "",
-      encoded: cached,
-      referenceType,
-      strength,
-      fidelity,
-    };
-  }
+  const cached = await readEncoded(entry.id);
+  if (cached) return { ...common, image: "", encoded: cached };
 
-  const image = await readAssetBase64(imagePath);
-  if (!image) return null;
-
+  const bytes = await Bun.file(source).arrayBuffer();
   const encoded = await encodeVibe({
-    image,
-    information_extracted: readNumber(record.infoExtracted, 0.7),
+    image: Buffer.from(bytes).toString("base64"),
+    information_extracted: entry.infoExtracted,
     model: ENCODE_MODEL,
   });
-  await writeEncoded(record.id, encoded);
-  // The list shows which entries are already paid for, so record it where the
-  // web can read it without asking for the blob itself.
-  await patchCollectionRecord("references", record.id, {
-    encodedAt: new Date().toISOString(),
-  });
+  await writeAtomic(encodedPath(entry.id), encoded);
+  await writeEntry({ ...entry, encodedAt: new Date().toISOString() });
 
-  return {
-    id: record.id,
-    kind,
-    image: "",
-    encoded,
-    referenceType,
-    strength,
-    fidelity,
-  };
+  return { ...common, image: "", encoded };
 }
 
+const metadataSchema = z.object({
+  name: z.string().min(1).max(200),
+  groupName: z.string().max(200).nullable().optional(),
+  kind: z.enum(["vibe", "reference"]),
+  strength: z.number().min(0).max(1),
+  infoExtracted: z.number().min(0).max(1),
+  referenceType: z.enum(["character", "style", "character&style"]),
+  fidelity: z.number().min(0).max(1),
+});
+
+const createBodySchema = metadataSchema.extend({
+  imageBase64: z.string().min(1),
+  contentType: z.string().min(1),
+});
+
+const resolveBodySchema = z.object({
+  ids: z.array(z.string().min(1)).min(1).max(32),
+});
+
+// An entry's image never changes: a different image is a different entry. So
+// the browser may keep it for as long as it likes.
+const IMMUTABLE = "public, max-age=31536000, immutable";
+
 export const referencesRouter = new Hono()
+  .get("/", async (c) => c.json({ items: await listEntries() }))
+  .post("/", zValidator("json", createBodySchema, onInvalid), async (c) => {
+    const { imageBase64, contentType, ...metadata } = c.req.valid("json");
+    const ext = EXT_BY_TYPE[contentType];
+    if (!ext) return c.json({ error: "Unsupported content type" }, 415);
+
+    const bytes = Buffer.from(imageBase64, "base64");
+    if (bytes.length === 0) return c.json({ error: "Empty image data" }, 400);
+    if (bytes.length > MAX_IMAGE_BYTES) {
+      return c.json({ error: "Image exceeds the 10 MB limit" }, 413);
+    }
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    // The image first: a directory holding metadata that points at nothing is
+    // the state this whole layout exists to avoid.
+    await mkdir(entryDir(id), { recursive: true });
+    await writeAtomic(join(entryDir(id), `image.${ext}`), bytes);
+    const entry: StoredReference = {
+      ...metadata,
+      id,
+      groupName: metadata.groupName ?? null,
+      encodedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await writeEntry(entry);
+    return c.json(entry, 201);
+  })
+  .put("/:id", zValidator("json", metadataSchema, onInvalid), async (c) => {
+    const id = c.req.param("id");
+    const current = await readEntry(id);
+    if (!current) return c.json({ error: "Reference not found" }, 404);
+
+    const patch = c.req.valid("json");
+    const next: StoredReference = {
+      ...current,
+      ...patch,
+      groupName: patch.groupName ?? null,
+      updatedAt: new Date().toISOString(),
+    };
+
+    // The encode is of one image at one information-extracted value. Change
+    // either and what is on disk no longer describes this entry, so it goes —
+    // here rather than in the browser, because the file is the server's.
+    if (
+      next.kind !== current.kind ||
+      next.infoExtracted !== current.infoExtracted
+    ) {
+      await deleteEncoded(id);
+      next.encodedAt = null;
+    }
+
+    await writeEntry(next);
+    return c.json(next);
+  })
+  .delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!ID_PATTERN.test(id)) return c.json({ error: "Invalid id" }, 400);
+    if (!(await readEntry(id))) {
+      return c.json({ error: "Reference not found" }, 404);
+    }
+    // One removal takes the image, the metadata and the encode together.
+    await rm(entryDir(id), { recursive: true, force: true });
+    return c.json({ ok: true });
+  })
+  .get("/:id/image", async (c) => {
+    const path = await imagePath(c.req.param("id"));
+    if (!path) return c.json({ error: "Reference image not found" }, 404);
+    const ext = path.slice(path.lastIndexOf(".") + 1);
+    const type = TYPE_BY_EXT[ext];
+    return new Response(Bun.file(path), {
+      headers: {
+        ...(type ? { "Content-Type": type } : {}),
+        "Cache-Control": IMMUTABLE,
+      },
+    });
+  })
   .post(
     "/resolve",
     zValidator("json", resolveBodySchema, onInvalid),
@@ -174,17 +360,14 @@ export const referencesRouter = new Hono()
         apiBase: env.NOVELAI_API_BASE,
       });
 
-      const records = (await readCollection("references")) as ReferenceRecord[];
-      const byId = new Map(records.map((record) => [record.id, record]));
-
       // Sequential: each miss is a paid network call, and doing them at once
       // only makes a rate limit more likely.
       const items: ResolvedReference[] = [];
       for (const id of c.req.valid("json").ids) {
-        const record = byId.get(id);
-        if (!record) continue;
+        const entry = await readEntry(id);
+        if (!entry) continue;
         try {
-          const resolved = await resolveOne(record, encodeVibe);
+          const resolved = await resolveOne(entry, encodeVibe);
           if (resolved) items.push(resolved);
         } catch (error) {
           // One bad entry must not lose the rest of the run. The caller reports
@@ -198,7 +381,9 @@ export const referencesRouter = new Hono()
   .delete("/:id/encoded", async (c) => {
     const id = c.req.param("id");
     if (!ID_PATTERN.test(id)) return c.json({ error: "Invalid id" }, 400);
+    const entry = await readEntry(id);
+    if (!entry) return c.json({ error: "Reference not found" }, 404);
     await deleteEncoded(id);
-    await patchCollectionRecord("references", id, { encodedAt: null });
+    await writeEntry({ ...entry, encodedAt: null });
     return c.json({ ok: true });
   });

--- a/apps/web/src/features/generate/components/reference-settings.tsx
+++ b/apps/web/src/features/generate/components/reference-settings.tsx
@@ -18,9 +18,9 @@ import { useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { LabeledSlider } from "@/components/labeled-slider";
-import { assetUrl } from "@/features/library/collections";
 import { SegmentedControl } from "@/components/segmented-control";
 import { ReferencePickerDialog } from "@/features/reference-library/components/reference-picker-dialog";
+import { referenceImageUrl } from "@/features/reference-library/lib/api";
 import { useReferences } from "@/features/reference-library/hooks/queries";
 import { useT } from "@/i18n/provider";
 import type { MessageKey } from "@/i18n/messages";
@@ -546,7 +546,7 @@ export function ReferenceSettings({ form, update }: Props) {
                   className="bg-muted flex max-w-full items-center gap-1 rounded-full border py-0.5 pr-0.5 pl-1.5 text-[10px]"
                 >
                   <img
-                    src={assetUrl(entry.imagePath)}
+                    src={referenceImageUrl(entry.id)}
                     alt=""
                     className="size-4 shrink-0 rounded-full object-cover"
                   />

--- a/apps/web/src/features/reference-library/components/reference-picker-dialog.tsx
+++ b/apps/web/src/features/reference-library/components/reference-picker-dialog.tsx
@@ -20,10 +20,10 @@ import { LabeledSlider } from "@/components/labeled-slider";
 import { readImageFile } from "@/features/generate/lib/image-file";
 import { REFERENCE_TYPES } from "@/features/generate/types/reference";
 import type { ReferenceType } from "@/features/generate/types/reference";
-import { assetUrl, uploadAsset } from "@/features/library/collections";
 import { useT } from "@/i18n/provider";
 
 import { useReferences } from "../hooks/queries";
+import { referenceImageUrl } from "../lib/api";
 import {
   createEmptyReference,
   searchableReferenceText,
@@ -62,7 +62,7 @@ export function ReferencePickerDialog({
   remaining,
 }: Props) {
   const t = useT();
-  const { references, save, remove } = useReferences();
+  const { references, create, save, remove } = useReferences();
   const [query, setQuery] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -116,16 +116,25 @@ export function ReferencePickerDialog({
     URL.revokeObjectURL(read.previewUrl);
     setBusy(true);
     try {
-      const uploaded = await uploadAsset(
-        read.imageBase64,
-        file.type || "image/png"
-      );
-      const entry = createEmptyReference(
+      const draft = createEmptyReference(
         kind,
-        file.name.replace(/\.[^.]+$/, "") || t("referenceLibrary.newName"),
-        uploaded.path
+        file.name.replace(/\.[^.]+$/, "") || t("referenceLibrary.newName")
       );
-      await save.mutateAsync(entry);
+      // One request: the server writes the image and the settings together, so
+      // a failure here leaves nothing half-made to clean up.
+      const entry = await create.mutateAsync({
+        metadata: {
+          name: draft.name,
+          groupName: draft.groupName,
+          kind: draft.kind,
+          strength: draft.strength,
+          infoExtracted: draft.infoExtracted,
+          referenceType: draft.referenceType,
+          fidelity: draft.fidelity,
+        },
+        imageBase64: read.imageBase64,
+        contentType: file.type || "image/png",
+      });
       setEditingId(entry.id);
     } catch {
       toast.error(t("referenceLibrary.saveError"));
@@ -245,7 +254,7 @@ export function ReferencePickerDialog({
                           >
                             <span className="bg-muted flex aspect-square w-full items-center justify-center overflow-hidden">
                               <img
-                                src={assetUrl(entry.imagePath)}
+                                src={referenceImageUrl(entry.id)}
                                 alt=""
                                 draggable={false}
                                 loading="lazy"

--- a/apps/web/src/features/reference-library/hooks/queries.ts
+++ b/apps/web/src/features/reference-library/hooks/queries.ts
@@ -3,24 +3,33 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
-  deleteAssetsByPath,
-  deleteCollectionItem,
-  listCollection,
-  saveCollectionItem,
-} from "@/features/library/collections";
-
-import { clearEncodedVibe } from "../lib/api";
+  createReference,
+  deleteReference,
+  listReferences,
+  updateReference,
+  type ReferenceMetadata,
+} from "../lib/api";
 import { normalizeReference, type ReferenceEntry } from "../types/reference";
 
-export const referencesQueryKey = ["collections", "references"] as const;
+export const referencesQueryKey = ["references"] as const;
 
 function sortReferences(entries: ReferenceEntry[]) {
   return [...entries].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 }
 
+/** A new entry, made from an image the person just picked. */
+export type NewReference = {
+  metadata: ReferenceMetadata;
+  imageBase64: string;
+  contentType: string;
+};
+
 /**
- * The saved reference images. Backed by the same local collections API as
- * characters and styles; the encode itself lives on the server, keyed by id.
+ * The saved reference images.
+ *
+ * The server owns an entry whole — image, settings and the cached encode live
+ * in one directory — so creating and deleting are each one request, and the
+ * encode is dropped server-side when a setting makes it wrong.
  */
 export function useReferences() {
   const queryClient = useQueryClient();
@@ -28,7 +37,7 @@ export function useReferences() {
   const query = useQuery({
     queryKey: referencesQueryKey,
     queryFn: async () => {
-      const { items } = await listCollection("references");
+      const { items } = await listReferences();
       return sortReferences(
         items.map((item, index) =>
           normalizeReference(item, `Reference ${index + 1}`)
@@ -37,41 +46,46 @@ export function useReferences() {
     },
   });
 
-  const save = useMutation({
-    mutationFn: async (entry: ReferenceEntry) => {
-      // A changed extraction makes the stored encode wrong, so it goes first.
-      // Leaving it would send a blob that no longer matches the settings.
-      const previous = query.data?.find((item) => item.id === entry.id);
-      if (previous && previous.infoExtracted !== entry.infoExtracted) {
-        await clearEncodedVibe(entry.id).catch(() => undefined);
-        entry = { ...entry, encodedAt: null };
+  function put(saved: ReferenceEntry) {
+    queryClient.setQueryData<ReferenceEntry[]>(
+      referencesQueryKey,
+      (current) => {
+        const list = current ?? [];
+        const exists = list.some((item) => item.id === saved.id);
+        return sortReferences(
+          exists
+            ? list.map((item) => (item.id === saved.id ? saved : item))
+            : [saved, ...list]
+        );
       }
-      await saveCollectionItem("references", entry);
-      return entry;
-    },
-    onSuccess: (saved) => {
-      queryClient.setQueryData<ReferenceEntry[]>(
-        referencesQueryKey,
-        (current) => {
-          const list = current ?? [];
-          const exists = list.some((item) => item.id === saved.id);
-          return sortReferences(
-            exists
-              ? list.map((item) => (item.id === saved.id ? saved : item))
-              : [saved, ...list]
-          );
-        }
-      );
-    },
+    );
+  }
+
+  const create = useMutation({
+    mutationFn: async (input: NewReference) =>
+      normalizeReference(
+        await createReference(
+          input.metadata,
+          input.imageBase64,
+          input.contentType
+        ),
+        input.metadata.name
+      ),
+    onSuccess: put,
+  });
+
+  const save = useMutation({
+    mutationFn: async (entry: ReferenceEntry) =>
+      normalizeReference(await updateReference(entry), entry.name),
+    onSuccess: put,
   });
 
   const remove = useMutation({
     mutationFn: async (entry: ReferenceEntry) => {
-      await clearEncodedVibe(entry.id).catch(() => undefined);
-      if (entry.imagePath) await deleteAssetsByPath([entry.imagePath]);
-      await deleteCollectionItem("references", entry.id);
+      await deleteReference(entry.id);
+      return entry;
     },
-    onSuccess: (_result, entry) => {
+    onSuccess: (entry) => {
       queryClient.setQueryData<ReferenceEntry[]>(
         referencesQueryKey,
         (current) => (current ?? []).filter((item) => item.id !== entry.id)
@@ -82,6 +96,7 @@ export function useReferences() {
   return {
     references: query.data ?? [],
     isPending: query.isPending,
+    create,
     save,
     remove,
   };

--- a/apps/web/src/features/reference-library/lib/api.ts
+++ b/apps/web/src/features/reference-library/lib/api.ts
@@ -1,6 +1,6 @@
-import { apiRequest } from "@/lib/api-client";
+import { apiRequest, serverUrl } from "@/lib/api-client";
 
-import type { ReferenceKind } from "../types/reference";
+import type { ReferenceEntry, ReferenceKind } from "../types/reference";
 
 /** What a generation needs from one library entry. */
 export type ResolvedReference = {
@@ -14,6 +14,68 @@ export type ResolvedReference = {
   strength: number;
   fidelity: number;
 };
+
+/** The metadata the server accepts. The image is set once, when created. */
+export type ReferenceMetadata = Pick<
+  ReferenceEntry,
+  | "name"
+  | "groupName"
+  | "kind"
+  | "strength"
+  | "infoExtracted"
+  | "referenceType"
+  | "fidelity"
+>;
+
+function metadataOf(entry: ReferenceEntry): ReferenceMetadata {
+  return {
+    name: entry.name,
+    groupName: entry.groupName,
+    kind: entry.kind,
+    strength: entry.strength,
+    infoExtracted: entry.infoExtracted,
+    referenceType: entry.referenceType,
+    fidelity: entry.fidelity,
+  };
+}
+
+export function listReferences() {
+  return apiRequest<{ items: ReferenceEntry[] }>("/references");
+}
+
+/**
+ * Creates an entry from an image and its settings in one request.
+ *
+ * The server writes the image and the metadata into one directory, so there is
+ * no moment where one exists without the other.
+ */
+export function createReference(
+  metadata: ReferenceMetadata,
+  imageBase64: string,
+  contentType: string
+) {
+  return apiRequest<ReferenceEntry>("/references", {
+    method: "POST",
+    body: { ...metadata, imageBase64, contentType },
+  });
+}
+
+export function updateReference(entry: ReferenceEntry) {
+  return apiRequest<ReferenceEntry>(`/references/${entry.id}`, {
+    method: "PUT",
+    body: metadataOf(entry),
+  });
+}
+
+/** Removes the image, the metadata and any cached encode together. */
+export function deleteReference(id: string) {
+  return apiRequest<{ ok: boolean }>(`/references/${id}`, { method: "DELETE" });
+}
+
+/** Where to show an entry's image from. */
+export function referenceImageUrl(id: string) {
+  return serverUrl(`/references/${id}/image`);
+}
 
 /**
  * Asks the server for the entries a run needs.

--- a/apps/web/src/features/reference-library/types/reference.ts
+++ b/apps/web/src/features/reference-library/types/reference.ts
@@ -19,14 +19,15 @@ export const REFERENCE_KIND_LABEL_KEYS: Record<ReferenceKind, string> = {
  * same `infoExtracted` always encodes to the same thing. The server keeps that
  * result on disk, so an entry here is paid for once and free every time after.
  * `encodedAt` is how the panel knows which is which.
+ *
+ * The image is not named here. It is always `/references/<id>/image`, so there
+ * is no stored path that can point at something that has been deleted.
  */
 export type ReferenceEntry = {
   id: string;
   name: string;
   groupName: string | null;
   kind: ReferenceKind;
-  /** Asset path of the source image. */
-  imagePath: string;
   /** When the vibe encode was cached. Null means the next use costs 2 Anlas. */
   encodedAt: string | null;
   strength: number;
@@ -47,8 +48,7 @@ export const DEFAULT_FIDELITY = 1;
 
 export function createEmptyReference(
   kind: ReferenceKind,
-  name: string,
-  imagePath: string
+  name: string
 ): ReferenceEntry {
   const now = new Date().toISOString();
   return {
@@ -56,7 +56,6 @@ export function createEmptyReference(
     name,
     groupName: null,
     kind,
-    imagePath,
     encodedAt: null,
     strength:
       kind === "vibe" ? DEFAULT_VIBE_STRENGTH : DEFAULT_REFERENCE_STRENGTH,
@@ -83,7 +82,7 @@ export function normalizeReference(
   input: unknown,
   fallbackName: string
 ): ReferenceEntry {
-  const base = createEmptyReference("vibe", fallbackName, "");
+  const base = createEmptyReference("vibe", fallbackName);
   if (!input || typeof input !== "object") return base;
 
   const kind =
@@ -104,7 +103,6 @@ export function normalizeReference(
     groupName:
       groupName && groupName.trim().length > 0 ? groupName.trim() : null,
     kind,
-    imagePath: readString(input, "imagePath") ?? "",
     encodedAt: encodedAt && encodedAt.length > 0 ? encodedAt : null,
     strength: readNumber(
       input,

--- a/docs/api.md
+++ b/docs/api.md
@@ -114,9 +114,9 @@ API では返さない。web が使っておらず、履歴の全件に付ける
 
 ## コレクション
 
-キャラクター・シチュエーション・スタイル・参照ライブラリの 4 種をレコード配列として保存する。
+キャラクター・シチュエーション・スタイルの 3 種をレコード配列として保存する。
 保存先は設定と同じ configDir を辿り、`<configDir>/collections/<name>.json` に書く。
-`<name>` は `characters` / `situations` / `styles` / `references` の 4 つだけで、それ以外は 404。
+`<name>` は `characters` / `situations` / `styles` の 3 つだけで、それ以外は 404。
 
 | メソッド | パス | 説明 |
 | --- | --- | --- |
@@ -139,15 +139,41 @@ API では返さない。web が使っておらず、履歴の全件に付ける
 ## 参照ライブラリ
 
 バイブ転送・精密参照に使う画像を保存しておき、生成のたびに貼り直さずに使う。
-レコード自体はコレクション `references`、画像はアセットに入るので、CRUD は
-それぞれの汎用エンドポイントを使う。ここにあるのは**エンコード結果の扱い**だけ。
+
+**1 件が 1 ディレクトリ。** 画像・設定・エンコード結果が同じ場所に入る。
+
+```
+<configDir>/references/<id>/
+├── reference.json   設定
+├── image.png        元画像（png / webp / jpg。content-type から決まる）
+└── encoded.txt      エンコード結果（バイブが 1 度エンコードされた後だけ）
+```
 
 | メソッド | パス | 説明 |
 | --- | --- | --- |
+| `GET` | `/references` | `{ items: Reference[] }`（`updatedAt` の新しい順） |
+| `POST` | `/references` | body に設定 + `{ imageBase64, contentType }` → 作成した `Reference`（201） |
+| `PUT` | `/references/:id` | 設定の更新。画像は変えられない。更新後の `Reference` |
+| `DELETE` | `/references/:id` | ディレクトリごと消す。`{ ok: true }`。無ければ 404 |
+| `GET` | `/references/:id/image` | 画像バイナリ。`Cache-Control: immutable` |
 | `POST` | `/references/resolve` | body `{ ids }` → `{ items: ResolvedReference[] }` |
 | `DELETE` | `/references/:id/encoded` | 保存済みエンコードを捨てる。`{ ok: true }` |
 
 ```ts
+type Reference = {
+  id: string;
+  name: string;
+  groupName: string | null;
+  kind: "vibe" | "reference";
+  strength: number;
+  infoExtracted: number;   // バイブのみ
+  referenceType: string;   // 精密参照のみ
+  fidelity: number;        // 精密参照のみ
+  encodedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 type ResolvedReference = {
   id: string;
   kind: "vibe" | "reference";
@@ -159,17 +185,19 @@ type ResolvedReference = {
 };
 ```
 
-**バイブのエンコードは 1 回だけ。** `/resolve` は、エンコード結果が
-`<configDir>/encoded-vibes/<id>.txt` に無いバイブだけをその場でエンコードして保存する。
-2 回目以降はファイルを読むだけなので Anlas を消費しない。同じ画像・同じ
-`information_extracted`・同じモデルなら結果は毎回同じなので、取っておけば足りる。
+画像のパスはレコードに持たない。常に `/references/<id>/image` なので、消えた画像を指したまま
+残る文字列が存在しない。作成も削除も 1 リクエストで、途中で失敗しても片方だけが残ることがない。
+
+**バイブのエンコードは 1 回だけ。** `/resolve` は、`encoded.txt` を持たないバイブだけを
+その場でエンコードして保存する。2 回目以降はファイルを読むだけなので Anlas を消費しない。
+同じ画像・同じ `information_extracted`・同じモデルなら結果は毎回同じなので、取っておけば足りる。
 
 エンコードのモデルは `nai-diffusion-4-5-full` に固定する。エンコード結果はモデル固有で、
 生成時のモデルに合わせると切り替えるたびにキャッシュが無効になり、保存する意味が消える。
 
-`information_extracted` を変えるとキャッシュは捨てられる（web 側が
-`DELETE /references/:id/encoded` を呼ぶ）。中身が変わったのに古い結果を送ると、
-設定と食い違ったものが出る。
+`infoExtracted` か `kind` を変えると、`PUT` が保存済みのエンコードを捨てる。中身が変わったのに
+古い結果を送ると設定と食い違ったものが出る。捨てるのはサーバ側の仕事で、ファイルを持っているのが
+サーバだから。
 
 解決できなかった id は落として返す。壊れた 1 件で生成 1 回分を失わないため。
 


### PR DESCRIPTION
## 変更内容

Closes #17

参照画像を「1 件 = 1 ディレクトリ」で持ち、サーバ側に参照そのものの CRUD を置いた。

```
<configDir>/references/<id>/
├── reference.json   設定
├── image.png        元画像
└── encoded.txt      エンコード結果（バイブが 1 度エンコードされた後だけ）
```

**これまではサーバに「参照」というリソースが無かった。** 1 件が 3 か所に分かれていて、

| 何が | どこに |
| --- | --- |
| メタデータ | `collections/references.json`（全件で 1 ファイル） |
| 画像 | `assets/<uuid>.png` |
| エンコード結果 | `encoded-vibes/<id>.txt` |

**作成は 2 回、削除は 3 回のリクエストをブラウザが順に投げて**成立していた。途中で止まれば
記録の無い画像、持ち主のいないエンコード結果（1 件 2 Anlas 払ったもの）、消えた画像を指し続ける
記録のいずれかが残り、サーバはそれを検知も修復もできなかった。

| メソッド | パス |
| --- | --- |
| `GET` | `/references` |
| `POST` | `/references`（画像と設定を 1 回で） |
| `PUT` | `/references/:id` |
| `DELETE` | `/references/:id`（ディレクトリごと） |
| `GET` | `/references/:id/image` |
| `POST` | `/references/resolve`（変更なし） |
| `DELETE` | `/references/:id/encoded`（変更なし） |

あわせて

- **画像のパスをレコードに持たない。** 常に `/references/<id>/image` なので、消えた画像を指したまま
  残る文字列が存在しない
- **`infoExtracted` / `kind` を変えたときのエンコード破棄をサーバ側に移した。** ファイルを持って
  いるのがサーバなので、そこが捨てるのが筋。これまではブラウザが別リクエストで消していた
- `references` を `collections` から外し、使われなくなった `readAssetBase64` /
  `readCollection` / `patchCollectionRecord` を消した

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] `bun run check-types`
- [x] `bun run build`
- [x] **隔離した config に対して全エンドポイントを実測**（20 件）

  作成 201 → ディスク上が `references/<id>/{image.png,reference.json}` になること、
  一覧・画像（`Content-Type: image/png` / `Cache-Control: immutable`）、
  415 / 400 / 404 / 400（不正 id）/ 428、`GET /collections/references` が 404 になり
  `characters` は 200 のままであること。

  エンコード破棄は `encoded.txt` を置いた状態から

  | 操作 | 結果 |
  | --- | --- |
  | `infoExtracted` を変えずに `PUT` | `encoded.txt` 残る / `encodedAt` 保持 |
  | `infoExtracted` を変えて `PUT` | `encoded.txt` 消える / `encodedAt` = null |
  | `DELETE /references/:id` | ディレクトリごと消える |

- [x] **ブラウザで実際に確認** — ライブラリを開く → 画像追加（1 リクエスト）→ タイルが
      `/references/<id>/image` から描画される（200 image/png）→ 削除で一覧が空に。
      コンソールエラー 0、失敗リクエスト 0。テスト後に設定ディレクトリが元の状態に戻ることも確認

## 備考

- 移行処理は入れていない。`collections/references.json` は `[]` のままで、参照ライブラリ自体が
  今日入ったばかりのため。**この空ファイルは読まれなくなるので、手で消して構わない**
- 画像は作成時に決まり、`PUT` では変えられない。別の画像は別のエントリという整理