### PR TITLE
fix(issues): trigger the close workflow on pull_request

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -5,13 +5,15 @@ name: Close linked issues
 # nothing else happens — PR #4 and #5 both said Closes and left their issues
 # open. This does the closing.
 #
-# pull_request_target rather than pull_request: the workflow then runs from
-# dev's copy of this file with a token that may write, instead of from the
-# branch being merged. Nothing from the pull request is checked out or run —
-# only its body is read, and it is passed through the environment rather than
-# into the shell, because a body can contain anything.
+# pull_request, not pull_request_target: the latter only starts when the file
+# is on the default branch, and this repository's default branch is main, which
+# nothing reaches until a release. It never ran once.
+#
+# Nothing from the pull request is checked out or run. Only its body is read,
+# and it goes through the environment rather than into the shell, because a
+# body can contain anything.
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
     branches: [dev]
 


### PR DESCRIPTION
## 変更内容

Closes #19
Closes #17

自動クローズのワークフローが **1 度も動いていなかった**ので、トリガーを
`pull_request_target` から `pull_request` に変えた。

PR #18 が `dev` にマージされても Issue #17 は閉じず、実行履歴も空だった。

```
$ gh api repos/.../actions/runs?event=pull_request_target --jq .total_count
0
$ gh workflow list
CI        active
Desktop   active      ← Close linked issues が登録すらされていない
```

`pull_request_target` は**既定ブランチにワークフローファイルが無いと起動しない**。

> This event will only trigger a workflow run if the workflow file exists on the default branch.
> — [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)

このリポジトリの既定ブランチは `main` で、`main` は `initial commit` のまま。ファイルは `dev` に
しかないので永久に発火しない。#15 を実装したときの調査漏れで、`pull_request_target` を選んだ
理由（書き込み権限が要る）は正しかったが、その制限を確認していなかった。

`pull_request` はこの制限を受けず、同一リポジトリの PR ではトークンに書き込み権限が付く。
PR 本文を env 経由で渡す扱いはそのまま残している（本文は信頼できない入力なので）。

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] YAML が期待どおりに解釈されること（`on.pull_request` / `permissions.issues=write` /
      `if: merged == true`）
- [x] リポジトリの既定トークン権限が `read` でも問題ないこと。設定は既定値であって上限ではなく、
      ワークフローの `permissions:` で上書きできる（[docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)）
- [x] **実際に閉じるかは、この PR のマージが初めての検証になる。** 本文に #19 と #17 の
      両方を書いてあるので、うまくいけば 2 件とも閉じる。閉じなければまだ直っていない

## 備考

`main` への PR は GitHub 本来の自動クローズが効くので、このワークフローは `dev` 宛てだけを見る。

fork からの PR は読み取り専用トークンになるため閉じられない。このリポジトリの運用では起きない。