### PR TITLE
feat(settings): choose which panel sections start expanded

### DIFF
--- a/apps/server/src/settings.ts
+++ b/apps/server/src/settings.ts
@@ -19,6 +19,12 @@ const storedSettingsSchema = z.object({
   defaultModel: z.string().min(1).optional(),
   plan: z.enum(["opus", "other"]).optional(),
   generationMode: z.enum(["queue", "alternate"]).optional(),
+  /**
+   * Which panel sections start expanded. Held as opaque strings: which
+   * sections exist is the web app's business, and a second list of names here
+   * would be one more place to keep in step.
+   */
+  openSections: z.array(z.string().min(1).max(40)).max(20).optional(),
 });
 type StoredSettings = z.infer<typeof storedSettingsSchema>;
 
@@ -37,6 +43,7 @@ type ResolvedSettings = {
   defaultModel: ImageModel;
   plan: Plan;
   generationMode: GenerationMode;
+  openSections: string[];
 };
 
 /** Public view returned to the client, without the API key. */
@@ -47,6 +54,7 @@ export type SettingsView = {
   defaultModel: ImageModel;
   plan: Plan;
   generationMode: GenerationMode;
+  openSections: string[];
 };
 
 function resolveDefaultModel(value?: string): ImageModel {
@@ -97,6 +105,9 @@ export async function getSettings(): Promise<ResolvedSettings> {
     // Default to "queue": the free path on Opus, so it never surprises the
     // user with an Anlas charge.
     generationMode: s.generationMode ?? "queue",
+    // The scene list is what a batch run is built from, so it is the one
+    // section worth opening before anything is asked for.
+    openSections: s.openSections ?? ["template"],
   };
 }
 
@@ -106,6 +117,7 @@ export type SettingsPatch = {
   defaultModel?: ImageModel;
   plan?: Plan;
   generationMode?: GenerationMode;
+  openSections?: string[];
 };
 
 export async function updateSettings(
@@ -120,6 +132,7 @@ export async function updateSettings(
   if (patch.generationMode !== undefined) {
     next.generationMode = patch.generationMode;
   }
+  if (patch.openSections !== undefined) next.openSections = patch.openSections;
   await persist(next);
   return getSettings();
 }
@@ -153,8 +166,10 @@ export function maskApiKey(key: string): string {
 
 /** Build the public view without exposing the raw API key. */
 export async function publicSettings(): Promise<SettingsView> {
-  const [{ outputDir, defaultModel, plan, generationMode }, apiKey] =
-    await Promise.all([getSettings(), getApiKey()]);
+  const [
+    { outputDir, defaultModel, plan, generationMode, openSections },
+    apiKey,
+  ] = await Promise.all([getSettings(), getApiKey()]);
   return {
     hasApiKey: apiKey !== null,
     apiKeyPreview: apiKey ? maskApiKey(apiKey) : null,
@@ -162,6 +177,7 @@ export async function publicSettings(): Promise<SettingsView> {
     defaultModel,
     plan,
     generationMode,
+    openSections,
   };
 }
 
@@ -186,6 +202,12 @@ const putBodySchema = z.object({
   defaultModel: z.enum(IMAGE_MODELS).optional(),
   plan: z.enum(["opus", "other"]).optional(),
   generationMode: z.enum(["queue", "alternate"]).optional(),
+  /**
+   * Which panel sections start expanded. Held as opaque strings: which
+   * sections exist is the web app's business, and a second list of names here
+   * would be one more place to keep in step.
+   */
+  openSections: z.array(z.string().min(1).max(40)).max(20).optional(),
 });
 
 const verifyBodySchema = z.object({

--- a/apps/web/src/features/generate/components/generate-panel.tsx
+++ b/apps/web/src/features/generate/components/generate-panel.tsx
@@ -10,12 +10,14 @@ import { ScrollArea } from "@nai-desktop-studio/ui/components/scroll-area";
 import { Separator } from "@nai-desktop-studio/ui/components/separator";
 import { cn } from "@nai-desktop-studio/ui/lib/utils";
 import { ChevronDown, Loader2, Square, WandSparkles } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { SegmentedControl } from "@/components/segmented-control";
+import { useSettings } from "@/features/settings/hooks/queries";
 import { useT } from "@/i18n/provider";
 
 import { aspectOfSize, SUPPORTS_CHARACTERS_PREFIX } from "../constants";
+import type { PanelSectionId } from "../constants";
 import type { FormState, GenerationMode } from "../types/generate";
 import type { TemplateSelection } from "../types/template";
 import { CharactersSection } from "./characters-section";
@@ -45,6 +47,13 @@ function Section({
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(defaultOpen);
+
+  // The setting arrives a moment after the first paint, and can change while
+  // the panel is on screen. Follow it both times. A section opened by hand
+  // stays open, because only a change to the setting runs this again.
+  useEffect(() => {
+    setOpen(defaultOpen);
+  }, [defaultOpen]);
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -112,6 +121,12 @@ export function GeneratePanel({
       ? form.vibes.length
       : form.references.length);
   const supportsCharacters = form.model.startsWith(SUPPORTS_CHARACTERS_PREFIX);
+  const { data: settings } = useSettings();
+  const openSections = settings?.openSections;
+  const startsOpen = useCallback(
+    (id: PanelSectionId) => openSections?.includes(id) ?? false,
+    [openSections]
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -138,7 +153,10 @@ export function GeneratePanel({
               hand-written character list would be two more sources of truth
               for the same thing. */}
           {mode === "batch" ? (
-            <Section title={t("generate.section.template")} defaultOpen>
+            <Section
+              title={t("generate.section.template")}
+              defaultOpen={startsOpen("template")}
+            >
               <TemplateSection
                 selection={templateSelection}
                 onSelectionChange={onTemplateSelectionChange}
@@ -158,6 +176,7 @@ export function GeneratePanel({
           {mode === "normal" && supportsCharacters && (
             <Section
               title={t("generate.section.characters")}
+              defaultOpen={startsOpen("characters")}
               badge={
                 form.characters.length > 0
                   ? String(form.characters.length)
@@ -174,12 +193,16 @@ export function GeneratePanel({
 
           <Section
             title={t("generate.section.reference")}
+            defaultOpen={startsOpen("reference")}
             badge={referenceCount > 0 ? String(referenceCount) : undefined}
           >
             <ReferenceSettings form={form} update={update} />
           </Section>
 
-          <Section title={t("generate.section.advanced")}>
+          <Section
+            title={t("generate.section.advanced")}
+            defaultOpen={startsOpen("advanced")}
+          >
             <AdvancedSettings form={form} update={update} />
           </Section>
         </div>

--- a/apps/web/src/features/generate/constants.ts
+++ b/apps/web/src/features/generate/constants.ts
@@ -136,3 +136,19 @@ export const CATEGORY_LABELS: Record<number, string> = {
   12: "Species",
   14: "Meta",
 };
+
+/**
+ * The panel sections that can be set to start expanded.
+ *
+ * The prompt, size and count fields are not here: they are always visible, and
+ * a setting for something that cannot be closed would be a switch attached to
+ * nothing.
+ */
+export const PANEL_SECTIONS = [
+  { id: "template", labelKey: "generate.section.template" },
+  { id: "characters", labelKey: "generate.section.characters" },
+  { id: "reference", labelKey: "generate.section.reference" },
+  { id: "advanced", labelKey: "generate.section.advanced" },
+] as const;
+
+export type PanelSectionId = (typeof PANEL_SECTIONS)[number]["id"];

--- a/apps/web/src/features/settings/components/settings-dialog.tsx
+++ b/apps/web/src/features/settings/components/settings-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@nai-desktop-studio/ui/components/button";
+import { Checkbox } from "@nai-desktop-studio/ui/components/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -20,6 +21,7 @@ import { Separator } from "@nai-desktop-studio/ui/components/separator";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { PANEL_SECTIONS } from "@/features/generate/constants";
 import type { MessageKey } from "@/i18n/messages";
 import { useT } from "@/i18n/provider";
 
@@ -74,6 +76,21 @@ export function SettingsDialog({ open, onOpenChange }: Props) {
     try {
       await saveSettings.mutateAsync({ generationMode });
       toast.success(t("settings.mode.saved"));
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : t("settings.output.errorSave")
+      );
+    }
+  }
+
+  const openSections = settings?.openSections ?? [];
+
+  async function toggleSection(id: string) {
+    const next = openSections.includes(id)
+      ? openSections.filter((item) => item !== id)
+      : [...openSections, id];
+    try {
+      await saveSettings.mutateAsync({ openSections: next });
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : t("settings.output.errorSave")
@@ -226,6 +243,32 @@ export function SettingsDialog({ open, onOpenChange }: Props) {
             </div>
             <p className="text-muted-foreground text-xs">
               {t("settings.output.help")}
+            </p>
+          </section>
+
+          <Separator />
+
+          {/* Checkboxes rather than one of the three "selected" idioms: this is
+              a set, not a choice among alternatives, and a checkbox is already
+              its own mark. */}
+          <section className="space-y-2">
+            <Label>{t("settings.sections.label")}</Label>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+              {PANEL_SECTIONS.map((section) => (
+                <Label
+                  key={section.id}
+                  className="flex items-center gap-2 py-1.5 font-normal"
+                >
+                  <Checkbox
+                    checked={openSections.includes(section.id)}
+                    onCheckedChange={() => void toggleSection(section.id)}
+                  />
+                  {t(section.labelKey)}
+                </Label>
+              ))}
+            </div>
+            <p className="text-muted-foreground text-xs">
+              {t("settings.sections.help")}
             </p>
           </section>
         </div>

--- a/apps/web/src/features/settings/types.ts
+++ b/apps/web/src/features/settings/types.ts
@@ -20,6 +20,8 @@ export type AppSettings = {
   /** Only affects the Anlas estimate, not what NovelAI charges. */
   plan: Plan;
   generationMode: GenerationMode;
+  /** Ids of the generate-panel sections that start expanded. */
+  openSections: string[];
 };
 
 export type SettingsPatch = {
@@ -28,6 +30,7 @@ export type SettingsPatch = {
   defaultModel?: string;
   plan?: Plan;
   generationMode?: GenerationMode;
+  openSections?: string[];
 };
 
 /** NovelAI subscription info. Used for the Anlas balance shown in the header. */

--- a/apps/web/src/i18n/messages/settings.ts
+++ b/apps/web/src/i18n/messages/settings.ts
@@ -45,6 +45,10 @@ const en = {
   "settings.output.errorEmpty": "Enter an output folder",
   "settings.output.saved": "Output folder updated",
   "settings.output.errorSave": "Could not save",
+
+  "settings.sections.label": "Sections open by default",
+  "settings.sections.help":
+    "Which parts of the generate panel are already expanded when the app opens.",
 } as const;
 
 const ja: Record<keyof typeof en, string> = {
@@ -94,6 +98,10 @@ const ja: Record<keyof typeof en, string> = {
   "settings.output.errorEmpty": "保存先を入力してください",
   "settings.output.saved": "保存先を変更しました",
   "settings.output.errorSave": "保存に失敗しました",
+
+  "settings.sections.label": "最初から開くセクション",
+  "settings.sections.help":
+    "生成パネルのどの部分を、起動した時点で開いておくかを選びます。",
 };
 
 export const settings = { en, ja };


### PR DESCRIPTION
## 変更内容

Closes #21

生成パネルのどのセクションを最初から開いておくかを、設定から選べるようにした。

複数選択なのでチェックボックスそのもので表す。`design.md` の「選ばれている」の言い方 3 つとは
別枠で、チェックボックスは自分自身が選択の印なので重ねて塗り分けない。

セクション名はサーバに持たせず、不透明な文字列の配列として `settings.json` に保存する。
どの区画があるかは web 側の都合で、サーバにもう 1 つ名前の一覧を置くとずれる場所が増える
（コレクションと同じ考え方）。

設定を変えると、開いているパネルにその場で反映される。手で開閉した状態は、設定そのものが
変わるまで維持される（`defaultOpen` が変わったときだけ追従する）。

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] `bun run check-types`
- [x] `bun run build`
- [x] **隔離したサーバで往復を実測**

  | 操作 | 結果 |
  | --- | --- |
  | 既定 | `["template"]` |
  | `PUT ["reference","advanced"]` | そのまま返り、`settings.json` にも保存 |
  | 空配列 | `[]`（全部たたむ、も選べる） |
  | 21 件以上 | 400 |

- [x] **ブラウザで実際に確認** — 設定に 4 つのチェックボックス（Template / Characters /
      Reference images / Advanced）が出る。2 つ選ぶとサーバの値が
      `["template","reference","advanced"]` になり、**ダイアログを閉じた時点でパネルの
      該当セクションが開いていた**。コンソールエラー 0

## 備考

既定値は `["template"]`。バッチのテンプレートだけが開いていた今までの挙動をそのまま残している。