### PR TITLE
feat(library): select, download and delete saved images

### DIFF
--- a/apps/web/src/features/generate/components/generate-workspace.tsx
+++ b/apps/web/src/features/generate/components/generate-workspace.tsx
@@ -444,6 +444,23 @@ export function GenerateWorkspace() {
           setViewedBatch(images);
           setSelectedIds([]);
         }}
+        onDownload={downloadImage}
+        onCopyPrompt={(image) =>
+          void copyWithToast(image.prompt, "image.copiedPrompt")
+        }
+        onDeleteImages={async (ids) => {
+          await library.deleteImages(ids);
+          // The viewer and lightbox may still hold images that are now gone.
+          const removed = new Set(ids);
+          setViewedBatch((current) =>
+            current ? current.filter((image) => !removed.has(image.id)) : null
+          );
+          setSelectedIds((current) => current.filter((id) => !removed.has(id)));
+          setLightboxId((current) =>
+            current && removed.has(current) ? null : current
+          );
+        }}
+        isDeleting={library.isDeleting}
       />
 
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />

--- a/apps/web/src/features/generate/components/library-dialog.tsx
+++ b/apps/web/src/features/generate/components/library-dialog.tsx
@@ -1,16 +1,37 @@
 "use client";
 
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@nai-desktop-studio/ui/components/alert-dialog";
+import { Button } from "@nai-desktop-studio/ui/components/button";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@nai-desktop-studio/ui/components/dialog";
-import { ImageIcon } from "lucide-react";
+import { cn } from "@nai-desktop-studio/ui/lib/utils";
+import {
+  Check,
+  Copy,
+  Download,
+  ImageIcon,
+  Loader2,
+  Trash2,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { useI18n } from "@/i18n/provider";
 
 import type { GeneratedImage } from "../types/image";
 import { formatBatchTime, groupHistoryByBatch } from "../utils/history";
-import { useI18n } from "@/i18n/provider";
 
 type Props = {
   open: boolean;
@@ -19,12 +40,19 @@ type Props = {
   resolveSrc: (image: GeneratedImage) => string;
   /** Opens a batch and replaces what the workspace shows. */
   onOpenBatch: (images: GeneratedImage[]) => void;
+  onDownload: (image: GeneratedImage) => void;
+  onCopyPrompt: (image: GeneratedImage) => void;
+  onDeleteImages: (ids: string[]) => Promise<unknown>;
+  isDeleting: boolean;
 };
 
 /**
- * List of saved images. The history strip at the bottom shows only the most
- * recent ones, so this is a separate entry point for reviewing past batches all
- * at once.
+ * Every saved image, and what can be done with them.
+ *
+ * The history strip only shows the most recent run, so this is where a past
+ * batch is found again — and where a run that did not work out is thrown away.
+ * Tiles select the way they do in the grid (ring plus a badge), because a
+ * second language for "this one is picked" would be one to learn for nothing.
  */
 export function LibraryDialog({
   open,
@@ -32,13 +60,57 @@ export function LibraryDialog({
   images,
   resolveSrc,
   onOpenBatch,
+  onDownload,
+  onCopyPrompt,
+  onDeleteImages,
+  isDeleting,
 }: Props) {
   const { t, locale } = useI18n();
   const groups = groupHistoryByBatch(images);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [confirming, setConfirming] = useState(false);
+
+  // A selection is about what is on screen now. Reopening the dialog should
+  // not resume one made before, and an image deleted elsewhere must not stay
+  // selected and get counted in the next action.
+  useEffect(() => {
+    if (!open) setSelectedIds([]);
+  }, [open]);
+  useEffect(() => {
+    const alive = new Set(images.map((image) => image.id));
+    setSelectedIds((current) => current.filter((id) => alive.has(id)));
+  }, [images]);
+
+  const selected = images.filter((image) => selectedIds.includes(image.id));
+  const onlySelected = selected.length === 1 ? selected[0] : null;
+
+  function toggle(id: string) {
+    setSelectedIds((current) =>
+      current.includes(id)
+        ? current.filter((item) => item !== id)
+        : [...current, id]
+    );
+  }
+
+  function toggleBatch(batch: GeneratedImage[]) {
+    const ids = batch.map((image) => image.id);
+    const allPicked = ids.every((id) => selectedIds.includes(id));
+    setSelectedIds((current) =>
+      allPicked
+        ? current.filter((id) => !ids.includes(id))
+        : [...current.filter((id) => !ids.includes(id)), ...ids]
+    );
+  }
+
+  async function deleteSelected() {
+    setConfirming(false);
+    await onDeleteImages(selectedIds);
+    setSelectedIds([]);
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] max-w-4xl">
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle>
             {t("viewer.library.title")} (
@@ -52,49 +124,191 @@ export function LibraryDialog({
             {t("viewer.library.empty")}
           </div>
         ) : (
-          <div className="max-h-[65vh] space-y-5 overflow-y-auto pr-1">
-            {groups.map((group) => (
-              <section key={group.batchId} className="space-y-2">
-                <div className="text-muted-foreground flex items-baseline gap-2 text-xs">
-                  <span className="tabular-nums">
-                    {formatBatchTime(group.createdAt, locale)}
-                  </span>
-                  <span className="tabular-nums">
-                    {t("unit.images", { count: group.images.length })}
-                  </span>
-                </div>
-                <div className="grid grid-cols-[repeat(auto-fill,minmax(7rem,1fr))] gap-2">
-                  {group.images.map((image) => (
-                    <button
-                      key={image.id}
-                      type="button"
-                      title={image.prompt || t("viewer.library.noPrompt")}
-                      // title isn't reliable as the accessible name, so set it
-                      // explicitly.
-                      aria-label={`${t("viewer.library.openImage", {
-                        time: formatBatchTime(image.createdAt, locale),
-                      })}${image.prompt ? ` (${image.prompt})` : ""}`}
-                      onClick={() => {
-                        onOpenBatch(group.images);
-                        onOpenChange(false);
-                      }}
-                      className="hover:ring-primary aspect-[3/4] overflow-hidden rounded-md border transition hover:ring-2"
-                    >
-                      <img
-                        src={resolveSrc(image)}
-                        alt=""
-                        loading="lazy"
-                        decoding="async"
-                        className="size-full object-cover"
-                      />
-                    </button>
-                  ))}
-                </div>
-              </section>
-            ))}
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto pr-1">
+            {groups.map((group) => {
+              const ids = group.images.map((image) => image.id);
+              const picked = ids.filter((id) =>
+                selectedIds.includes(id)
+              ).length;
+
+              return (
+                <section key={group.batchId} className="space-y-2">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <div className="text-muted-foreground flex items-baseline gap-2 font-mono text-xs tabular-nums">
+                      <span>{formatBatchTime(group.createdAt, locale)}</span>
+                      <span>
+                        {t("unit.images", { count: group.images.length })}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      {picked > 0 && (
+                        <span className="text-primary font-mono text-[11px] tabular-nums">
+                          {t("viewer.library.pickedInBatch", { count: picked })}
+                        </span>
+                      )}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => toggleBatch(group.images)}
+                      >
+                        {picked === ids.length
+                          ? t("viewer.library.deselectBatch")
+                          : t("viewer.library.selectBatch")}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => {
+                          onOpenBatch(group.images);
+                          onOpenChange(false);
+                        }}
+                      >
+                        {t("viewer.library.openBatch")}
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-[repeat(auto-fill,minmax(7rem,1fr))] gap-2">
+                    {group.images.map((image) => {
+                      const isSelected = selectedIds.includes(image.id);
+
+                      return (
+                        <button
+                          key={image.id}
+                          type="button"
+                          aria-pressed={isSelected}
+                          title={image.prompt || t("viewer.library.noPrompt")}
+                          aria-label={`${t("viewer.library.openImage", {
+                            time: formatBatchTime(image.createdAt, locale),
+                          })}${image.prompt ? ` (${image.prompt})` : ""}`}
+                          onClick={() => toggle(image.id)}
+                          onDoubleClick={() => {
+                            onOpenBatch(group.images);
+                            onOpenChange(false);
+                          }}
+                          className={cn(
+                            "bg-card relative overflow-hidden rounded-md border transition-[box-shadow] duration-150 ease-out",
+                            isSelected
+                              ? "ring-primary ring-offset-card ring-2 ring-offset-2"
+                              : "hover:ring-primary/40 hover:ring-2"
+                          )}
+                        >
+                          <span className="relative block aspect-[3/4] w-full">
+                            <img
+                              src={resolveSrc(image)}
+                              alt=""
+                              loading="lazy"
+                              decoding="async"
+                              className="pointer-events-none size-full object-cover"
+                            />
+                            {isSelected && (
+                              <>
+                                <span
+                                  className="bg-primary/10 pointer-events-none absolute inset-0"
+                                  aria-hidden
+                                />
+                                <span className="bg-primary text-primary-foreground ring-background absolute top-1.5 right-1.5 flex size-5 items-center justify-center rounded-full ring-2">
+                                  <Check
+                                    className="size-3"
+                                    strokeWidth={3}
+                                    aria-hidden
+                                  />
+                                </span>
+                              </>
+                            )}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Only present while something is picked. A bar of disabled buttons
+            waiting for a selection is furniture. */}
+        {selected.length > 0 && (
+          <div className="flex shrink-0 items-center justify-between gap-2 border-t pt-3">
+            <span className="font-mono text-xs tabular-nums">
+              {t("viewer.library.selectedCount", { count: selected.length })}
+            </span>
+            <div className="flex items-center gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setSelectedIds([])}
+              >
+                {t("viewer.library.clearSelection")}
+              </Button>
+              {onlySelected && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onCopyPrompt(onlySelected)}
+                >
+                  <Copy className="mr-1 size-3.5" aria-hidden />
+                  {t("viewer.action.copyPrompt")}
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => selected.forEach(onDownload)}
+              >
+                <Download className="mr-1 size-3.5" aria-hidden />
+                {t("viewer.action.download")}
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                disabled={isDeleting}
+                onClick={() => setConfirming(true)}
+              >
+                {isDeleting ? (
+                  <Loader2 className="mr-1 size-3.5 animate-spin" aria-hidden />
+                ) : (
+                  <Trash2 className="mr-1 size-3.5" aria-hidden />
+                )}
+                {t("action.delete")}
+              </Button>
+            </div>
           </div>
         )}
       </DialogContent>
+
+      <AlertDialog open={confirming} onOpenChange={setConfirming}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("viewer.library.deleteTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("viewer.library.deleteDescription", {
+                count: selected.length,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("action.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => void deleteSelected()}
+            >
+              {t("action.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   );
 }

--- a/apps/web/src/features/generate/hooks/use-image-library.ts
+++ b/apps/web/src/features/generate/hooks/use-image-library.ts
@@ -54,6 +54,40 @@ export function useImageLibrary() {
     },
   });
 
+  /**
+   * Removes several images at once.
+   *
+   * One request each, in order: the server deletes a file per call and a local
+   * one is fast, while firing dozens at once only makes the failure modes
+   * harder to report. The cache is updated once at the end so the grid does
+   * not reflow per image.
+   */
+  const removeMany = useMutation({
+    mutationFn: async (ids: string[]) => {
+      const deleted: string[] = [];
+      for (const id of ids) {
+        try {
+          await deleteImage(id);
+          deleted.push(id);
+        } catch {
+          // An image already gone from disk should not stop the rest.
+        }
+      }
+      return deleted;
+    },
+    onSuccess: (deleted) => {
+      const gone = new Set(deleted);
+      queryClient.setQueryData<{ images: GeneratedImage[] }>(
+        imagesQueryKey,
+        (current) => ({
+          images: (current?.images ?? []).filter(
+            (image) => !gone.has(image.id)
+          ),
+        })
+      );
+    },
+  });
+
   const clear = useMutation({
     mutationFn: () => clearImages(),
     onSuccess: () => {
@@ -66,6 +100,8 @@ export function useImageLibrary() {
     isPending: query.isPending,
     addImage,
     deleteImage: remove.mutate,
+    deleteImages: removeMany.mutateAsync,
+    isDeleting: removeMany.isPending,
     clearImages: clear.mutate,
   };
 }

--- a/apps/web/src/features/settings/components/settings-dialog.tsx
+++ b/apps/web/src/features/settings/components/settings-dialog.tsx
@@ -117,7 +117,7 @@ export function SettingsDialog({ open, onOpenChange }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("settings.title")}</DialogTitle>
         </DialogHeader>

--- a/apps/web/src/i18n/messages/viewer.ts
+++ b/apps/web/src/i18n/messages/viewer.ts
@@ -47,6 +47,15 @@ const en = {
   "viewer.library.empty": "No images yet",
   "viewer.library.noPrompt": "No prompt",
   "viewer.library.openImage": "Open image from {time}",
+  "viewer.library.openBatch": "Open run",
+  "viewer.library.selectBatch": "Select run",
+  "viewer.library.deselectBatch": "Deselect run",
+  "viewer.library.pickedInBatch": "{count} picked",
+  "viewer.library.selectedCount": "{count} selected",
+  "viewer.library.clearSelection": "Clear",
+  "viewer.library.deleteTitle": "Delete these images?",
+  "viewer.library.deleteDescription":
+    "{count} image(s) will be removed from the output folder. This cannot be undone.",
 } as const;
 
 const ja: Record<keyof typeof en, string> = {
@@ -91,6 +100,15 @@ const ja: Record<keyof typeof en, string> = {
   "viewer.library.empty": "まだ画像がありません",
   "viewer.library.noPrompt": "プロンプトなし",
   "viewer.library.openImage": "{time} の画像を開く",
+  "viewer.library.openBatch": "この回を開く",
+  "viewer.library.selectBatch": "この回を選択",
+  "viewer.library.deselectBatch": "選択を外す",
+  "viewer.library.pickedInBatch": "{count} 枚選択中",
+  "viewer.library.selectedCount": "{count} 枚を選択中",
+  "viewer.library.clearSelection": "選択を解除",
+  "viewer.library.deleteTitle": "画像を削除しますか",
+  "viewer.library.deleteDescription":
+    "{count} 枚を保存先フォルダから削除します。元には戻せません。",
 };
 
 export const viewer = { en, ja };


### PR DESCRIPTION
## 変更内容

Closes #23

ライブラリのダイアログを、見るだけの一覧から操作できる場所にした。

- タイルを選べる（複数）。選択の見た目は**グリッドと同じ**（`ring-primary` ＋ 右上のチェック
  バッジ ＋ `bg-primary/10`）。`design.md` の「選ばれている」の言い方 3 つに新しいものを足さない
- バッチ単位でまとめて選ぶ / 外す。バッチごとに選択枚数を出す
- 選んだものをダウンロード / 削除。削除は枚数を示して確認を挟む
- 1 枚だけ選んでいるときはプロンプトをコピーできる
- クリックで選択、ダブルクリックでバッチを開く（グリッドと同じ分け方）
- 削除した画像はビューア・ライトボックス・選択からも消す
- 選択はダイアログを閉じると捨てる。開き直して前の選択が残っていると、次の操作の対象が変わる

一括削除は 1 件ずつ順に送る。サーバは 1 回につき 1 ファイルを消すだけで、ローカルなら速い。
まとめて投げても速くならず、失敗の報告だけが難しくなる。

**あわせて既存の不具合を 1 つ直した。** `library-dialog` は `max-w-4xl` を指定しているのに、
`DialogContent` の既定にある `sm:max-w-sm` が 640px 以上で勝つため、**実際には 384px で
表示されていた**（実測）。他のダイアログは全部 `sm:max-w-*` で書いてあり、設定ダイアログにも
同じ書き間違いがあったので両方直した。

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] `bun run check-types`
- [x] `bun run build`
- [x] **幅を実測**。修正前 384px → 修正後 896px
- [x] **ブラウザで実際に確認**（画像 45 枚）

  タイル 45 個が並び、2 枚クリックで `aria-pressed` が 2 個、下部に `2 selected` の操作バーが出る。
  「Select run」でバッチ単位の選択が増える。「Delete」で
  `3 image(s) will be removed from the output folder. This cannot be undone.` の確認が出る。

  **キャンセル後にサーバの画像は 45 枚のまま**（実際の削除は実行していない）。コンソールエラー 0

- [ ] 削除の実行そのものは、ユーザーの画像が消えるため画面からは実行していない。
      サーバの `DELETE /images/:id` は隔離した出力ディレクトリに対して 200 / 404 を確認済み

## 備考

前提: #22（`feat/21-open-sections`）の上に積んである。