### PR TITLE
feat(novelai): price V5 generations in the Anlas estimate

### DIFF
--- a/packages/novelai/src/client.ts
+++ b/packages/novelai/src/client.ts
@@ -9,10 +9,12 @@ import {
   SMEA_DYN_MULTIPLIER,
   SMEA_MULTIPLIER,
   STEP_AREA_COEFFICIENT,
+  V5_COST_MULTIPLIER,
   VIBE_EXTRA_ANLAS,
   VIBE_FREE_COUNT,
 } from "./constants";
 import { buildGeneratePayload, resolveModel, resolveSize } from "./payload";
+import { isV5Model } from "./schemas";
 import { iterateStreamFrames } from "./sse";
 import type { StreamFrame } from "./sse";
 import { extractAllFilesFromZip, isZipPayload } from "./zip";
@@ -184,8 +186,9 @@ export function estimateAnlas(body: EstimateAnlasBody) {
   const baseCost = Math.ceil(
     AREA_COEFFICIENT * area + STEP_AREA_COEFFICIENT * area * steps
   );
+  const versionMultiplier = isV5Model(model) ? V5_COST_MULTIPLIER : 1;
   const perImageAnlas = Math.max(
-    Math.ceil(baseCost * multiplier * strengthFactor),
+    Math.ceil(baseCost * versionMultiplier * multiplier * strengthFactor),
     2
   );
 
@@ -198,8 +201,13 @@ export function estimateAnlas(body: EstimateAnlasBody) {
   // Vibe surcharges exist on V4/V4.5 only. V3 predates vibes as billed here,
   // and V5 has no vibe transfer at all, so the prefix check excludes both.
   const supportsV4Costs = model.startsWith("nai-diffusion-4");
+  // V5 sits outside Opus unlimited (it is battery-metered instead), so the
+  // free-sample discount never applies there. The estimate is what a
+  // generation costs once the battery is empty; the battery itself is not
+  // visible to the API.
   const opusDiscountApplied = Boolean(
     body.is_opus &&
+    !isV5Model(model) &&
     area <= LIGHTWEIGHT_OPUS_MAX_PIXELS &&
     steps <= LIGHTWEIGHT_OPUS_MAX_STEPS
   );

--- a/packages/novelai/src/constants.ts
+++ b/packages/novelai/src/constants.ts
@@ -97,6 +97,10 @@ export const AREA_COEFFICIENT = 2.951823174884865e-6;
 export const STEP_AREA_COEFFICIENT = 5.753298233447344e-7;
 export const SMEA_MULTIPLIER = 1.2;
 export const SMEA_DYN_MULTIPLIER = 1.4;
+// V5 bills ~30% over the V4 curve. No official formula is published;
+// ceil(v4BaseCost * 1.3) matches the measured 28-step per-image costs
+// (11 / 26 / 39 for small / normal / large, where V4 pays 8 / 20 / 30).
+export const V5_COST_MULTIPLIER = 1.3;
 export const MAX_PER_IMAGE_ANLAS = 140;
 export const LIGHTWEIGHT_OPUS_MAX_PIXELS = 1_048_576;
 export const LIGHTWEIGHT_OPUS_MAX_STEPS = 28;


### PR DESCRIPTION
## 変更内容

Anlas 見積を V5 の課金に合わせた。#29 で「V4 系と同じ式のまま」と割り切った部分の解消。

- V5 は Opus 割引(小さい生成の 1 枚無料)の対象外にした。V5 は Opus 無制限の対象外(バッテリー制)なので、割引を付けると常に過小に出る
- V5 の per-image コストに `V5_COST_MULTIPLIER = 1.3` を掛ける。公式の式は未公開なので、実測 3 点(28 steps で 小 11 / 標準 832x1216 26 / 大 1024x1536 39。V4 系は 8 / 20 / 30)に一致する「切り上げ後ベースコスト × 1.3 を再切り上げ」を採用
- 表示側(`useAnlasEstimate` → 生成ボタン)はサーバーの数字をそのまま出しているので、Web 層の変更なしで V5 + Opus の「Free」誤表示が直る

見積の実測一致は次で確認した(V4 系は 1 Anlas も変わらない):

```
V5 small 512x768     per: 11   V5 normal 832x1216   per: 26   V5 large 1024x1536   per: 39
V4.5 normal          per: 20   V4.5 large           per: 30
V5 normal opus       total: 26(割引なし)   V4.5 normal opus   total: 0(従来どおり)
```

Closes #34

## 確認したこと

- [x] `bun run check`(oxlint + oxfmt)
- [x] `bun run check-types`
- [x] `bun run build`
- [x] 実際に動かして確認した

## 備考

- バッテリー残量は API から見えないため、V5 の数字は「バッテリー切れ後に払う額」(安全側の上限)。残量があるあいだの実消費は 0
