### PR TITLE
feat(novelai): model-specific quality tags and V5 UC presets

### DIFF
--- a/apps/web/src/features/generate/lib/compose.ts
+++ b/apps/web/src/features/generate/lib/compose.ts
@@ -8,8 +8,8 @@ import {
 } from "@/features/situations/lib/template";
 import {
   assembleStyledPrompt,
-  NEGATIVE_GROUP,
-  QUALITY_GROUP,
+  negativeGroup,
+  qualityGroup,
 } from "@/features/styles/lib/style-prompt";
 import type { Style } from "@/features/styles/types/style";
 
@@ -92,7 +92,7 @@ export function composeTemplatePrompt(
               joinParts([entry.gender ?? "", entry.prompt])
             ),
           ]),
-      QUALITY_GROUP,
+      qualityGroup(model),
       style?.styleTag ?? "",
       style?.promptPosition ?? "after_quality"
     ),
@@ -103,7 +103,7 @@ export function composeTemplatePrompt(
             baseNegative,
             ...entries.map((entry) => entry.negativePrompt),
           ]),
-      NEGATIVE_GROUP,
+      negativeGroup(model),
       style?.negativeTag ?? "",
       style?.negativePosition ?? "after_quality"
     ),

--- a/apps/web/src/features/styles/lib/style-prompt.ts
+++ b/apps/web/src/features/styles/lib/style-prompt.ts
@@ -1,6 +1,7 @@
 import {
   QUALITY_TAGS,
   UC_PRESET_TEXT,
+  V5_UC_PRESET_TEXT,
 } from "@nai-desktop-studio/novelai/constants";
 
 import type { StylePromptPosition } from "../types/style";
@@ -14,8 +15,25 @@ function joinTags(parts: string[]): string {
     .join(", ");
 }
 
-export const QUALITY_GROUP = joinTags([QUALITY_TAGS]);
-export const NEGATIVE_GROUP = joinTags([UC_PRESET_TEXT.light]);
+/**
+ * The model's quality tags as a clean group. Quality tags differ per model, so
+ * the group is looked up rather than fixed; an unknown model falls back to the
+ * package default (V4.5 Full).
+ */
+export function qualityGroup(model: string): string {
+  const tags =
+    QUALITY_TAGS[model as keyof typeof QUALITY_TAGS] ??
+    QUALITY_TAGS["nai-diffusion-4-5-full"];
+  return joinTags([tags]);
+}
+
+/** The model's Light UC preset as a clean group. V5 rewrote it. */
+export function negativeGroup(model: string): string {
+  const presets = model.startsWith("nai-diffusion-5")
+    ? V5_UC_PRESET_TEXT
+    : UC_PRESET_TEXT;
+  return joinTags([presets.light]);
+}
 
 /**
  * Builds the final prompt with the quality block up front and the style tag at

--- a/packages/novelai/src/constants.ts
+++ b/packages/novelai/src/constants.ts
@@ -2,7 +2,6 @@ export const NOVELAI_IMAGE_BASE = "https://image.novelai.net";
 // /user/subscription currently lives on the image host; api.novelai.net
 // returns 400.
 export const NOVELAI_API_BASE = "https://image.novelai.net";
-export const QUALITY_TAGS = ", very aesthetic, masterpiece, no text";
 
 export const IMAGE_MODELS = [
   "nai-diffusion-5-full",
@@ -14,6 +13,25 @@ export const IMAGE_MODELS = [
   "nai-diffusion-3",
   "nai-diffusion-3-furry",
 ] as const;
+
+/**
+ * Quality tags the official app appends per model
+ * (docs.novelai.net/en/image/qualitytags). V5 also has a lighter set behind a
+ * level picker; the quality switch here is on/off, so V5 gets the standard set.
+ */
+export const QUALITY_TAGS = {
+  "nai-diffusion-5-full": ", very aesthetic, masterpiece, no text",
+  "nai-diffusion-5-curated": ", very aesthetic, masterpiece, no text",
+  "nai-diffusion-4-5-full": ", location, very aesthetic, masterpiece, no text",
+  "nai-diffusion-4-5-curated":
+    ", location, masterpiece, no text, -0.8::feet::, rating:general",
+  "nai-diffusion-4-full": ", no text, best quality, very aesthetic, absurdres",
+  "nai-diffusion-4-curated":
+    ", rating:general, amazing quality, very aesthetic, absurdres",
+  "nai-diffusion-3":
+    ", best quality, amazing quality, very aesthetic, absurdres",
+  "nai-diffusion-3-furry": ", {best quality}, {amazing quality}",
+} as const satisfies Record<(typeof IMAGE_MODELS)[number], string>;
 
 export const SIZE_PRESETS = {
   portrait: { width: 832, height: 1216 },
@@ -33,6 +51,16 @@ export const UC_PRESET_TEXT = {
   human_focus:
     ", lowres, artistic error, film grain, scan artifacts, worst quality, bad quality, jpeg artifacts, very displeasing, chromatic aberration, dithering, halftone, screentone, multiple views, logo, too many watermarks, negative space, blank page, @_@, mismatched pupils, glowing eyes, bad anatomy, ",
   none: "",
+} as const;
+
+/**
+ * V5 rewrote the Light preset (docs.novelai.net/en/image/undesiredcontent);
+ * the other presets match V4.5, so only the difference lives here.
+ */
+export const V5_UC_PRESET_TEXT = {
+  ...UC_PRESET_TEXT,
+  light:
+    ", lowres, bad hands, bad anatomy, artistic error, sepia, white haze, worst quality, very displeasing, jpeg artifacts, 0::ai-generated::, ",
 } as const;
 
 export const UC_PRESET_INT = {

--- a/packages/novelai/src/payload.ts
+++ b/packages/novelai/src/payload.ts
@@ -3,6 +3,7 @@ import {
   SIZE_PRESETS,
   UC_PRESET_INT,
   UC_PRESET_TEXT,
+  V5_UC_PRESET_TEXT,
 } from "./constants";
 import { isV4Model, isV45Model, isV5Model } from "./schemas";
 import type {
@@ -82,11 +83,15 @@ function buildCharacterPrompts(characters: GenerateImageBody["characters"]) {
 }
 
 function resolvePrompt(body: GenerateImageBody) {
-  return body.quality === false ? body.prompt : `${body.prompt}${QUALITY_TAGS}`;
+  if (body.quality === false) return body.prompt;
+  return `${body.prompt}${QUALITY_TAGS[resolveModel(body.model)]}`;
 }
 
 function resolveNegativePrompt(body: GenerateImageBody) {
-  return `${body.negative_prompt ?? ""}${UC_PRESET_TEXT[body.uc_preset ?? "light"]}`;
+  const presets = isV5Model(resolveModel(body.model))
+    ? V5_UC_PRESET_TEXT
+    : UC_PRESET_TEXT;
+  return `${body.negative_prompt ?? ""}${presets[body.uc_preset ?? "light"]}`;
 }
 
 function resolveAction(body: GenerateImageBody | GenerateImageStreamBody) {


### PR DESCRIPTION
## 変更内容

品質タグと UC プリセットをモデル別にし、V5 の公式プリセットを正しく送るようにした。

- `QUALITY_TAGS` を 1 本の文字列からモデル別のテーブルに変更([公式ドキュメント](https://docs.novelai.net/en/image/qualitytags/)の文字列をそのまま採用)。これまでの文字列は V5 の標準セットで、V4.5 Full の `location` や V4/V3 の `best quality` / `absurdres` 系が落ちていた
- `V5_UC_PRESET_TEXT` を追加。V5 で書き換わったのは Light だけなので、差分の Light のみ持ち、Heavy / Human Focus / Furry Focus は V4.5 と共有([公式ドキュメント](https://docs.novelai.net/en/image/undesiredcontent/))
- `resolvePrompt` / `resolveNegativePrompt` がモデルからテーブルを引く
- styles の `QUALITY_GROUP` / `NEGATIVE_GROUP` 定数は `qualityGroup(model)` / `negativeGroup(model)` 関数にし、バッチ合成(compose)もモデルに追随

ペイロードのスモークで各モデルの付与文字列が公式と一致することを確認した(V5 Light の negative、V4.5 Full の `location` 入りなど)。

Closes #32

## 確認したこと

- [x] `bun run check`(oxlint + oxfmt)
- [x] `bun run check-types`
- [x] `bun run build`
- [x] 実際に動かして確認した

## 備考

- V5 の品質タグには Light / Standard の 2 段階があるが、アプリの品質スイッチは on/off なので Standard を採用(従来の文字列と同一)
- V5 API の `tag_hint_qt` / `tag_hint_uc_preset` は意味・値の仕様が未確認のため送っていない(Issue の注記どおり)
- V4/V3 の UC プリセット文字列は従来のまま(公式は Heavy/Light の 2 種で内容も別だが、選択肢の再設計が要るので今回のスコープ外)
