### PR TITLE
feat(generate): build Text: blocks for V5 text rendering

### DIFF
--- a/apps/web/src/features/generate/lib/build-request.ts
+++ b/apps/web/src/features/generate/lib/build-request.ts
@@ -47,6 +47,22 @@ function characterCaption(gender: string | null, prompt: string) {
     .join(", ");
 }
 
+/**
+ * The official V5 frontend prepares the Text: block (text rendering) from
+ * "quoted" prompt text; V4.5 needs the block written by hand. A hand-written
+ * block turns the automation off — that is the official behavior too.
+ */
+function withAutoTextBlock(prompt: string, model: string) {
+  if (!model.startsWith("nai-diffusion-5")) return prompt;
+  if (/(?:^|\n)Text:/.test(prompt)) return prompt;
+  const texts = [...prompt.matchAll(/"([^"\n]+)"/g)]
+    .map((match) => (match[1] ?? "").trim())
+    .filter(Boolean);
+  if (texts.length === 0) return prompt;
+  // Multiple pieces of text are separated by an empty line, per the docs.
+  return `${prompt}\nText: ${texts.join("\n\n")}`;
+}
+
 function parseSeed(value: string) {
   const trimmed = value.trim();
   // An empty field means "random". Number("") is 0, so without this guard we
@@ -101,7 +117,7 @@ export function buildGenerateRequest(
     supportsReferences(form.model);
 
   return {
-    prompt: form.prompt.trim(),
+    prompt: withAutoTextBlock(form.prompt.trim(), form.model),
     ...(form.negativePrompt.trim()
       ? { negative_prompt: form.negativePrompt.trim() }
       : {}),

--- a/packages/novelai/src/payload.ts
+++ b/packages/novelai/src/payload.ts
@@ -82,9 +82,32 @@ function buildCharacterPrompts(characters: GenerateImageBody["characters"]) {
   }));
 }
 
+/**
+ * Where the prompt's Text: block starts, or -1. Text rendering reads
+ * everything from a line beginning with "Text:" to the end as rendered text.
+ */
+function findTextBlock(prompt: string) {
+  const match = /(?:^|\n)Text:/.exec(prompt);
+  if (!match) return -1;
+  return match.index + (match[0].startsWith("\n") ? 1 : 0);
+}
+
+/**
+ * Quality tags go at the end of the tag part, not the end of the prompt:
+ * appended after a Text: block they would be drawn into the image as text.
+ */
 function resolvePrompt(body: GenerateImageBody) {
   if (body.quality === false) return body.prompt;
-  return `${body.prompt}${QUALITY_TAGS[resolveModel(body.model)]}`;
+  const quality = QUALITY_TAGS[resolveModel(body.model)];
+  const start = findTextBlock(body.prompt);
+  if (start === -1) return `${body.prompt}${quality}`;
+  const tags = body.prompt.slice(0, start).trimEnd();
+  const textBlock = body.prompt.slice(start);
+  // Every entry in QUALITY_TAGS begins with ", ", which has nothing to attach
+  // to when the prompt is only a Text: block.
+  return tags
+    ? `${tags}${quality}\n${textBlock}`
+    : `${quality.slice(2)}\n${textBlock}`;
 }
 
 function resolveNegativePrompt(body: GenerateImageBody) {


### PR DESCRIPTION
## 変更内容

テキスト描画([公式ドキュメント](https://docs.novelai.net/en/image/textrendering/))に対応した。2 層で 1 つずつ:

- **パッケージ層(payload)**: 品質タグをプロンプト末尾ではなく「タグ部分の末尾」に入れるようにした。これまでは `Text:` ブロックの後ろに連結され、`Text: こんにちは, very aesthetic, masterpiece, no text` のようにタグが描画テキストへ混ざって壊れていた。`Text:` ブロック(行頭の `Text:` 以降)を探し、その手前に品質タグを差し込む。手書き `Text:` を使う V4.5 でも効く
- **Web 層(build-request)**: V5 では公式フロントエンドと同じく、プロンプト中の `"引用文字列"` から `Text:` ブロックを自動生成する。手書きの `Text:` があるときは自動生成しない(公式仕様)。複数の引用は空行区切りで 1 ブロックにまとめる。V4 系では何もしない

スモークで確認した挙動:

- `1girl, sign\nText: Hello` → `1girl, sign, very aesthetic, masterpiece, no text\nText: Hello`
- V5 で `1girl, "Hi", banner, "Bye"` → 末尾に `Text: Hi\n\nBye` が付く
- 行中の `Text:`(タグの一部)はブロック扱いしない。quality オフ時は素通し

Closes #35

## 確認したこと

- [x] `bun run check`(oxlint + oxfmt)
- [x] `bun run check-types`
- [x] `bun run build`
- [x] 実際に動かして確認した

## 備考

- 自動生成の対象は半角ダブルクォートのみ。全角引用符(「」や『』)の扱いは公式仕様が確認でき次第
- 引用文字列はプロンプト本文にも残す(公式も残す仕様。本文への繰り返しは描画の安定に効くとドキュメントにもある)
