### PR TITLE
feat(generate): free character placement on V5 models

### DIFF
--- a/apps/web/src/features/generate/components/character-picker-dialog.tsx
+++ b/apps/web/src/features/generate/components/character-picker-dialog.tsx
@@ -47,6 +47,8 @@ type Props = {
   onActiveChange: (id: string) => void;
   /** width / height of the image being made, so the frame matches it. */
   aspect: number;
+  /** V5 places anywhere on the frame; older models use the 5x5 grid. */
+  freeform: boolean;
   /** Saves a subject change back to the character record. */
   onCharacterChange: (character: Character) => void;
   /** Opens the character manager, so a missing character can be added here. */
@@ -71,6 +73,7 @@ export function CharacterPickerDialog({
   activeId,
   onActiveChange,
   aspect,
+  freeform,
   onCharacterChange,
   onManage,
 }: Props) {
@@ -290,6 +293,7 @@ export function CharacterPickerDialog({
                       };
                     })}
                     aspect={aspect}
+                    freeform={freeform}
                     activeId={activeId}
                     onActiveChange={onActiveChange}
                     onPositionChange={(id, position) =>
@@ -308,6 +312,7 @@ export function CharacterPickerDialog({
                   onActiveChange={onActiveChange}
                   onPickedChange={onPickedChange}
                   onCharacterChange={onCharacterChange}
+                  freeform={freeform}
                 />
               </>
             )}

--- a/apps/web/src/features/generate/components/character-placement-grid.tsx
+++ b/apps/web/src/features/generate/components/character-placement-grid.tsx
@@ -8,13 +8,15 @@ import { assetUrl } from "@/features/library/collections";
 import { useT } from "@/i18n/provider";
 
 import { POSITION_GRID } from "../constants";
+import { cellCenter, describePosition, snapToCell } from "../lib/placement";
+import type { PlacementPoint } from "../types/generate";
 
 export type PlacementEntry = {
   id: string;
   /** Names the one being placed. Falls back to the cell badge when there is no picture. */
   label: string;
-  /** A1..E5, or null to let NovelAI choose. */
-  position: string | null;
+  /** A1..E5 or a free point (V5), or null to let NovelAI choose. */
+  position: string | PlacementPoint | null;
   /** The character's picture, when it has one. Hand-typed characters do not. */
   imagePath?: string | null;
 };
@@ -23,9 +25,14 @@ type Props = {
   entries: PlacementEntry[];
   activeId: string | null;
   onActiveChange: (id: string) => void;
-  onPositionChange: (id: string, position: string | null) => void;
+  onPositionChange: (
+    id: string,
+    position: string | PlacementPoint | null
+  ) => void;
   /** width / height of the image being made. The frame takes the same shape. */
   aspect: number;
+  /** V5 places anywhere on the frame; the grid is for models that cannot. */
+  freeform: boolean;
   className?: string;
 };
 
@@ -43,6 +50,18 @@ function frameWidth(aspect: number) {
   if (aspect >= 1.2) return "max-w-72";
   if (aspect <= 0.85) return "max-w-52";
   return "max-w-60";
+}
+
+/** Finer than anyone can aim, and it keeps the request numbers readable. */
+function roundCoordinate(value: number) {
+  return Math.round(Math.min(Math.max(value, 0), 1) * 100) / 100;
+}
+
+/** What a grid surface treats a position as: free points snap to their cell. */
+function cellOf(position: PlacementEntry["position"]) {
+  return position && typeof position !== "string"
+    ? snapToCell(position)
+    : position;
 }
 
 /**
@@ -69,6 +88,7 @@ export function CharacterPlacementGrid({
   onActiveChange,
   onPositionChange,
   aspect,
+  freeform,
   className,
 }: Props) {
   const t = useT();
@@ -77,7 +97,7 @@ export function CharacterPlacementGrid({
   const active = entries[activeIndex] ?? null;
   const untouched = entries.every((entry) => entry.position === null);
 
-  function place(position: string | null) {
+  function place(position: string | PlacementPoint | null) {
     if (!active) return;
     onPositionChange(active.id, position);
     const next = entries[activeIndex + 1];
@@ -99,7 +119,7 @@ export function CharacterPlacementGrid({
             {active.position ? (
               <>
                 <span className="text-muted-foreground shrink-0 font-mono text-[10px] tabular-nums">
-                  {active.position}
+                  {describePosition(active.position, freeform)}
                 </span>
                 <Button
                   type="button"
@@ -128,67 +148,137 @@ export function CharacterPlacementGrid({
         )}
       </div>
 
-      {/* One bordered frame divided by hairlines, not 25 bordered boxes. A
-          viewfinder's grid is an overlay on the picture; boxes with gaps read
-          as a keypad. */}
-      <div
-        style={{ aspectRatio: aspect }}
-        className={cn(
-          "bg-muted/30 mx-auto grid w-full grid-cols-5 grid-rows-5 overflow-hidden rounded-md border",
-          frameWidth(aspect)
-        )}
-      >
-        {CELLS.map((cell, index) => {
-          const here = entries
-            .map((entry, order) => ({ entry, order }))
-            .filter(({ entry }) => entry.position === cell);
-          const isActiveCell = active?.position === cell;
-          const lastColumn = index % COLUMNS === COLUMNS - 1;
-          const lastRow = index >= CELLS.length - COLUMNS;
-
-          return (
-            <button
-              key={cell}
-              type="button"
-              disabled={!active}
-              aria-pressed={isActiveCell}
-              onClick={() => place(isActiveCell ? null : cell)}
-              title={
-                active
-                  ? t("generate.placement.cell", { name: active.label, cell })
-                  : cell
+      {freeform ? (
+        // The same frame with no cells: V5 takes the exact spot, so the frame
+        // is a surface, not a keypad. A position set on the grid before the
+        // model switch shows at its cell's center until it is placed again.
+        <div
+          style={{ aspectRatio: aspect }}
+          className={cn(
+            "bg-muted/30 relative mx-auto w-full overflow-hidden rounded-md border",
+            frameWidth(aspect)
+          )}
+        >
+          <button
+            type="button"
+            disabled={!active}
+            title={
+              active
+                ? t("generate.placement.point", { name: active.label })
+                : undefined
+            }
+            onClick={(event) => {
+              // A keyboard "click" carries no coordinates (detail 0); give it
+              // the center rather than the frame's top-left corner.
+              if (event.detail === 0) {
+                place({ x: 0.5, y: 0.5 });
+                return;
               }
-              className={cn(
-                "focus-visible:ring-ring border-border/60 relative flex items-center justify-center gap-0.5 outline-none transition-colors duration-150 ease-out focus-visible:z-10 focus-visible:ring-1 focus-visible:ring-inset disabled:pointer-events-none",
-                !lastColumn && "border-r",
-                !lastRow && "border-b",
-                // The same pair as every other chosen option — secondary fill,
-                // primary edge — said with an inset ring, because the cell has
-                // no border of its own to turn.
-                isActiveCell
-                  ? "bg-secondary ring-primary z-10 ring-1 ring-inset"
-                  : "hover:bg-muted/70"
-              )}
-            >
-              {here.map(({ entry, order }) => (
+              const frame = event.currentTarget.getBoundingClientRect();
+              place({
+                x: roundCoordinate((event.clientX - frame.left) / frame.width),
+                y: roundCoordinate((event.clientY - frame.top) / frame.height),
+              });
+            }}
+            className="focus-visible:ring-ring hover:bg-muted/70 absolute inset-0 cursor-crosshair outline-none transition-colors duration-150 ease-out focus-visible:ring-1 focus-visible:ring-inset disabled:pointer-events-none"
+          >
+            <span className="sr-only">
+              {active
+                ? t("generate.placement.point", { name: active.label })
+                : ""}
+            </span>
+          </button>
+          {entries.map((entry, order) => {
+            if (!entry.position) return null;
+            const point =
+              typeof entry.position === "string"
+                ? cellCenter(entry.position)
+                : entry.position;
+            return (
+              <span
+                key={entry.id}
+                className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2"
+                style={{
+                  left: `${point.x * 100}%`,
+                  top: `${point.y * 100}%`,
+                }}
+              >
                 <Occupant
-                  key={entry.id}
                   entry={entry}
                   index={order}
                   active={entry.id === activeId}
                 />
-              ))}
-              <span className="sr-only">{cell}</span>
-            </button>
-          );
-        })}
-      </div>
+              </span>
+            );
+          })}
+        </div>
+      ) : (
+        // One bordered frame divided by hairlines, not 25 bordered boxes. A
+        // viewfinder's grid is an overlay on the picture; boxes with gaps read
+        // as a keypad.
+        <div
+          style={{ aspectRatio: aspect }}
+          className={cn(
+            "bg-muted/30 mx-auto grid w-full grid-cols-5 grid-rows-5 overflow-hidden rounded-md border",
+            frameWidth(aspect)
+          )}
+        >
+          {CELLS.map((cell, index) => {
+            const here = entries
+              .map((entry, order) => ({ entry, order }))
+              .filter(({ entry }) => cellOf(entry.position) === cell);
+            const isActiveCell = active
+              ? cellOf(active.position) === cell
+              : false;
+            const lastColumn = index % COLUMNS === COLUMNS - 1;
+            const lastRow = index >= CELLS.length - COLUMNS;
+
+            return (
+              <button
+                key={cell}
+                type="button"
+                disabled={!active}
+                aria-pressed={isActiveCell}
+                onClick={() => place(isActiveCell ? null : cell)}
+                title={
+                  active
+                    ? t("generate.placement.cell", { name: active.label, cell })
+                    : cell
+                }
+                className={cn(
+                  "focus-visible:ring-ring border-border/60 relative flex items-center justify-center gap-0.5 outline-none transition-colors duration-150 ease-out focus-visible:z-10 focus-visible:ring-1 focus-visible:ring-inset disabled:pointer-events-none",
+                  !lastColumn && "border-r",
+                  !lastRow && "border-b",
+                  // The same pair as every other chosen option — secondary fill,
+                  // primary edge — said with an inset ring, because the cell has
+                  // no border of its own to turn.
+                  isActiveCell
+                    ? "bg-secondary ring-primary z-10 ring-1 ring-inset"
+                    : "hover:bg-muted/70"
+                )}
+              >
+                {here.map(({ entry, order }) => (
+                  <Occupant
+                    key={entry.id}
+                    entry={entry}
+                    index={order}
+                    active={entry.id === activeId}
+                  />
+                ))}
+                <span className="sr-only">{cell}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {/* Only until the first one is placed. The auto-advance is worth saying
           once; repeating it forever turns instructions into furniture. */}
       {active && untouched && (
         <p className="text-muted-foreground/80 text-[10px] leading-snug">
-          {t("generate.placement.hint")}
+          {t(
+            freeform ? "generate.placement.hintFree" : "generate.placement.hint"
+          )}
         </p>
       )}
     </div>

--- a/apps/web/src/features/generate/components/characters-section.tsx
+++ b/apps/web/src/features/generate/components/characters-section.tsx
@@ -11,6 +11,7 @@ import { TagAutocompleteTextarea } from "@/components/tag-autocomplete/tag-autoc
 import { useT } from "@/i18n/provider";
 
 import { DEFAULT_CHARACTER } from "../constants";
+import { describePosition } from "../lib/placement";
 import type { CharacterData, FormState } from "../types/generate";
 import { CharacterPlacementGrid } from "./character-placement-grid";
 
@@ -19,6 +20,8 @@ type Props = {
   update: (patch: Partial<FormState>) => void;
   /** width / height of the image being made, so the frame matches it. */
   aspect: number;
+  /** V5 places anywhere on the frame; older models use the 5x5 grid. */
+  freeform: boolean;
 };
 
 /** The first tag of a character's prompt, which is usually enough to tell it apart. */
@@ -26,7 +29,12 @@ function firstTag(prompt: string) {
   return prompt.split(",")[0]?.trim() ?? "";
 }
 
-export function CharactersSection({ characters, update, aspect }: Props) {
+export function CharactersSection({
+  characters,
+  update,
+  aspect,
+  freeform,
+}: Props) {
   const t = useT();
   // Which character the grid places. Kept as an index because a form character
   // has no id — it is only its slot in the list.
@@ -56,6 +64,7 @@ export function CharactersSection({ characters, update, aspect }: Props) {
               position: character.position,
             }))}
             aspect={aspect}
+            freeform={freeform}
             activeId={String(active)}
             onActiveChange={(id) => setActiveIndex(Number(id))}
             onPositionChange={(id, position) =>
@@ -81,7 +90,7 @@ export function CharactersSection({ characters, update, aspect }: Props) {
               {t("generate.character.n", { index: index + 1 })}
               {character.position && (
                 <span className="font-mono tabular-nums">
-                  {character.position}
+                  {describePosition(character.position, freeform)}
                 </span>
               )}
             </span>

--- a/apps/web/src/features/generate/components/generate-panel.tsx
+++ b/apps/web/src/features/generate/components/generate-panel.tsx
@@ -19,6 +19,7 @@ import { useT } from "@/i18n/provider";
 import { aspectOfSize } from "../constants";
 import type { PanelSectionId } from "../constants";
 import { supportsCharacters as modelSupportsCharacters } from "../lib/build-request";
+import { supportsFreePlacement } from "../lib/placement";
 import type { FormState, GenerationMode } from "../types/generate";
 import type { TemplateSelection } from "../types/template";
 import { CharactersSection } from "./characters-section";
@@ -163,6 +164,7 @@ export function GeneratePanel({
                 onSelectionChange={onTemplateSelectionChange}
                 perScene={form.nSamples}
                 aspect={aspectOfSize(form.size)}
+                freeform={supportsFreePlacement(form.model)}
               />
             </Section>
           ) : (
@@ -188,6 +190,7 @@ export function GeneratePanel({
                 characters={form.characters}
                 update={update}
                 aspect={aspectOfSize(form.size)}
+                freeform={supportsFreePlacement(form.model)}
               />
             </Section>
           )}

--- a/apps/web/src/features/generate/components/selected-character-list.tsx
+++ b/apps/web/src/features/generate/components/selected-character-list.tsx
@@ -9,6 +9,7 @@ import { CharacterThumbnail } from "@/features/characters/components/character-t
 import type { Character } from "@/features/characters/lib/template";
 import { useT } from "@/i18n/provider";
 
+import { describePosition } from "../lib/placement";
 import type { TemplateCharacterPick } from "../types/template";
 
 type Props = {
@@ -28,6 +29,8 @@ type Props = {
    * through rather than kept as a per-run override that a reload would lose.
    */
   onCharacterChange?: (character: Character) => void;
+  /** V5 places anywhere on the frame; older models use the 5x5 grid. */
+  freeform: boolean;
 };
 
 /**
@@ -47,6 +50,7 @@ export function SelectedCharacterList({
   onActiveChange,
   onPickedChange,
   onCharacterChange,
+  freeform,
 }: Props) {
   const t = useT();
   const selectable = onActiveChange !== undefined;
@@ -112,7 +116,7 @@ export function SelectedCharacterList({
                 grid already shows who is on it. */}
               {entry.position && (
                 <span className="text-muted-foreground shrink-0 font-mono text-[10px] tabular-nums">
-                  {entry.position}
+                  {describePosition(entry.position, freeform)}
                 </span>
               )}
               <Button

--- a/apps/web/src/features/generate/components/template-section.tsx
+++ b/apps/web/src/features/generate/components/template-section.tsx
@@ -31,6 +31,8 @@ type Props = {
   perScene: number;
   /** width / height of the image being made, passed to the placement frame. */
   aspect: number;
+  /** V5 places anywhere on the frame; older models use the 5x5 grid. */
+  freeform: boolean;
 };
 
 type Manager = "situations" | "characters" | "styles";
@@ -85,6 +87,7 @@ export function TemplateSection({
   onSelectionChange,
   perScene,
   aspect,
+  freeform,
 }: Props) {
   const t = useT();
   const { situations } = useSituations();
@@ -209,6 +212,7 @@ export function TemplateSection({
             picked={selection.characters}
             characters={characters}
             onPickedChange={setPicked}
+            freeform={freeform}
           />
         )}
       </div>
@@ -261,6 +265,7 @@ export function TemplateSection({
         activeId={effectiveActiveId}
         onActiveChange={setActiveId}
         aspect={aspect}
+        freeform={freeform}
         onCharacterChange={(character) =>
           save.mutate({ ...character, updatedAt: new Date().toISOString() })
         }

--- a/apps/web/src/features/generate/lib/build-request.ts
+++ b/apps/web/src/features/generate/lib/build-request.ts
@@ -1,4 +1,5 @@
 import type { FormState, GenerateRequestBody } from "../types/generate";
+import { resolvePlacement } from "./placement";
 
 /**
  * An encoded vibe. Built once at the start of the batch and reused for every
@@ -100,8 +101,11 @@ export function buildGenerateRequest(
             ? { negative_prompt: character.negativePrompt.trim() }
             : {}),
           // Don't send it when no position is set (sending it turns on
-          // use_coords).
-          ...(character.position ? { position: character.position } : {}),
+          // use_coords). A free point snaps to its grid cell for models that
+          // only know the grid.
+          ...(character.position
+            ? { position: resolvePlacement(character.position, form.model) }
+            : {}),
         }))
     : undefined;
 

--- a/apps/web/src/features/generate/lib/compose.ts
+++ b/apps/web/src/features/generate/lib/compose.ts
@@ -14,13 +14,18 @@ import {
 import type { Style } from "@/features/styles/types/style";
 
 import { SAMPLER_OPTIONS } from "../constants";
-import type { CharacterData, FormState, Sampler } from "../types/generate";
+import type {
+  CharacterData,
+  FormState,
+  PlacementPoint,
+  Sampler,
+} from "../types/generate";
 import { supportsCharacters } from "./build-request";
 
 /** A character picked for the next generation, with where to place it. */
 export type SelectedCharacter = {
   character: Character;
-  position: string | null;
+  position: string | PlacementPoint | null;
 };
 
 /** A selection with every id already looked up in its collection. */

--- a/apps/web/src/features/generate/lib/placement.ts
+++ b/apps/web/src/features/generate/lib/placement.ts
@@ -1,0 +1,55 @@
+import type { PlacementPoint } from "../types/generate";
+
+/**
+ * V5 places characters anywhere on the frame; V4-series models only know the
+ * 5x5 grid.
+ */
+export function supportsFreePlacement(model: string) {
+  return model.startsWith("nai-diffusion-5");
+}
+
+/** Center of a grid cell like "B2" in 0-1 coordinates. */
+export function cellCenter(cell: string): PlacementPoint {
+  const column = "ABCDE".indexOf(cell.charAt(0));
+  const row = "12345".indexOf(cell.charAt(1));
+  return { x: (column + 0.5) / 5, y: (row + 0.5) / 5 };
+}
+
+/**
+ * The grid cell a free point falls in, for surfaces and models that only know
+ * the grid.
+ */
+export function snapToCell(point: PlacementPoint): string {
+  const cap = (value: number) =>
+    Math.min(Math.max(Math.floor(value * 5), 0), 4);
+  return `${"ABCDE".charAt(cap(point.x))}${cap(point.y) + 1}`;
+}
+
+/**
+ * The position a request may carry for this model. A free point placed on V5
+ * snaps to its grid cell when the model is switched to one that only knows
+ * the grid, so the request stays one the model understands.
+ */
+export function resolvePlacement(
+  position: string | PlacementPoint,
+  model: string
+) {
+  if (typeof position === "string" || supportsFreePlacement(model)) {
+    return position;
+  }
+  return snapToCell(position);
+}
+
+/**
+ * How a position reads in the UI. A free point shows as percentages of the
+ * frame; on a grid surface it shows as the cell it snaps to, so the label
+ * matches what the frame draws and what the request will carry.
+ */
+export function describePosition(
+  position: string | PlacementPoint,
+  freeform: boolean
+): string {
+  if (typeof position === "string") return position;
+  if (!freeform) return snapToCell(position);
+  return `${Math.round(position.x * 100)}%, ${Math.round(position.y * 100)}%`;
+}

--- a/apps/web/src/features/generate/types/generate.ts
+++ b/apps/web/src/features/generate/types/generate.ts
@@ -19,11 +19,20 @@ export type Sampler = (typeof SAMPLER_OPTIONS)[number];
 export type NoiseSchedule = (typeof NOISE_SCHEDULE_OPTIONS)[number];
 export type UcPreset = (typeof UC_PRESET_OPTIONS)[number]["value"];
 
+/**
+ * A free placement on the frame, in 0-1 fractions of its width and height.
+ * Only V5 models take it as-is; older models snap it to the 5x5 grid.
+ */
+export type PlacementPoint = { x: number; y: number };
+
 export type CharacterData = {
   prompt: string;
   negativePrompt: string;
-  /** A1..E5 placement preset. null sends no position and lets NovelAI decide. */
-  position: string | null;
+  /**
+   * A1..E5 placement preset or a free point (V5). null sends no position and
+   * lets NovelAI decide.
+   */
+  position: string | PlacementPoint | null;
   /** Prepended to this character's caption at send time. Null adds nothing. */
   gender: CharacterGender | null;
   enabled: boolean;
@@ -89,7 +98,7 @@ export type GenerateRequestBody = {
   characters?: {
     prompt: string;
     negative_prompt?: string;
-    position?: string;
+    position?: string | PlacementPoint;
   }[];
   i2i?: {
     image: string;

--- a/apps/web/src/features/generate/types/template.ts
+++ b/apps/web/src/features/generate/types/template.ts
@@ -1,8 +1,10 @@
+import type { PlacementPoint } from "./generate";
+
 /** A character picked for the next generation, and where it stands. */
 export type TemplateCharacterPick = {
   id: string;
-  /** A1..E5, or null to let NovelAI choose. */
-  position: string | null;
+  /** A1..E5 or a free point (V5), or null to let NovelAI choose. */
+  position: string | PlacementPoint | null;
 };
 
 /**

--- a/apps/web/src/i18n/messages/generate.ts
+++ b/apps/web/src/i18n/messages/generate.ts
@@ -94,10 +94,13 @@ const en = {
   "generate.placement.label": "Placement",
   "generate.placement.hint":
     "Click a cell to place them. The next character takes over after that.",
+  "generate.placement.hintFree":
+    "Click anywhere on the frame to place them. The next character takes over after that.",
   "generate.placement.hintEmpty": "Add a character to place it.",
   "generate.placement.none": "Anywhere",
   "generate.placement.clear": "Take off the frame",
   "generate.placement.cell": "Place “{name}” at {cell}",
+  "generate.placement.point": "Place “{name}” where you click",
 
   "generate.picker.title": "Choose characters",
   "generate.picker.description":
@@ -306,10 +309,13 @@ const ja: Record<keyof typeof en, string> = {
   "generate.placement.label": "配置",
   "generate.placement.hint":
     "セルを押すと配置します。そのあとは次のキャラクターに移ります。",
+  "generate.placement.hintFree":
+    "フレームの好きな位置を押すと配置します。そのあとは次のキャラクターに移ります。",
   "generate.placement.hintEmpty": "キャラクターを追加すると配置できます。",
   "generate.placement.none": "指定なし",
   "generate.placement.clear": "位置を外す",
   "generate.placement.cell": "「{name}」を {cell} に配置",
+  "generate.placement.point": "「{name}」を押した位置に配置",
 
   "generate.picker.title": "キャラクターを選択",
   "generate.picker.description":


### PR DESCRIPTION
## 変更内容

V5 のとき、キャラクター配置をフレーム上の任意の位置(0〜1 の自由座標)で指定できるようにした。V5 の公式アップデートでグリッド制約が外れたことへの追随([公式ドキュメント](https://docs.novelai.net/en/image/multiplecharacters/)。API 側は v4_prompt の `centers` が元々自由座標で、caru-ini/novelai-sdk#84 で実リクエスト確認済み)。

- `PlacementPoint`(`{x, y}` 0〜1)を追加し、position の型を `string | PlacementPoint | null` に広げた。パッケージ層の characterSchema は対応済みなので変更なし
- `lib/placement.ts` を新設: `supportsFreePlacement` / `cellCenter` / `snapToCell` / `resolvePlacement` / `describePosition`
- 配置フレーム(`CharacterPlacementGrid`)に `freeform` を追加。V5 ではセルなしの一枚のサーフェスになり、クリック位置がそのまま座標になる(0.01 刻み。キーボード操作は中央に配置)。V4 系は従来の 5x5 グリッド
- モデル切替の整合: V5 で自由配置 → V4 系に切り替えると、リクエストは最寄りのセルにスナップ(`resolvePlacement`)、グリッド表示・位置ラベルも同じセルを示す。逆方向(グリッド→V5)はセル中心の点として表示
- 通常モードとバッチモード(キャラクターピッカー・選択リスト)の両方に `freeform` を通した
- 位置ラベルは自由配置ではパーセント表示(例: `62%, 41%`)、グリッドでは従来どおりセル名

Closes #31

## 確認したこと

- [x] `bun run check`(oxlint + oxfmt)
- [x] `bun run check-types`
- [x] `bun run build`
- [x] 実際に動かして確認した

## 備考

- 公式は最大 22 キャラまで動作確認とのことだが、本アプリのキャラ数に上限は元々無いので上限変更はしていない
- 自由配置サーフェスにグリッド補助線のオーバーレイ(公式のオプション相当)は付けていない。要望があれば別 Issue で
