### PR TITLE
feat(settings): choose the default model, starting at V5

### DIFF
--- a/apps/server/src/settings.ts
+++ b/apps/server/src/settings.ts
@@ -9,7 +9,9 @@ import type { ImageModel } from "@nai-desktop-studio/novelai";
 import { onInvalid } from "./http";
 import { configDir, defaultOutputDir } from "./paths";
 
-const DEFAULT_MODEL: ImageModel = "nai-diffusion-4-5-full";
+// V5 is the current mainline model, so a fresh install starts there. Anyone
+// preferring another model saves it once from the settings screen.
+const DEFAULT_MODEL: ImageModel = "nai-diffusion-5-full";
 const SETTINGS_FILE = "settings.json";
 
 /** Settings as stored on disk. Every field is optional. */

--- a/apps/web/src/features/generate/components/generate-workspace.tsx
+++ b/apps/web/src/features/generate/components/generate-workspace.tsx
@@ -3,18 +3,19 @@
 import { cn } from "@nai-desktop-studio/ui/lib/utils";
 import { ImageIcon } from "lucide-react";
 import { toast } from "sonner";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { MessageKey } from "@/i18n/messages";
 import { useT } from "@/i18n/provider";
 
 import { useCharacters } from "@/features/characters/hooks/queries";
 import { SettingsDialog } from "@/features/settings/components/settings-dialog";
+import { useSettings } from "@/features/settings/hooks/queries";
 import { useSituations } from "@/features/situations/hooks/queries";
 import { useStyles } from "@/features/styles/hooks/queries";
 import type { Style } from "@/features/styles/types/style";
 
-import { INITIAL_FORM } from "../constants";
+import { INITIAL_FORM, MODEL_OPTIONS } from "../constants";
 import { useAnlasEstimate } from "../hooks/use-anlas-estimate";
 import { useGenerationEngine } from "../hooks/use-generation-engine";
 import { useImageLibrary } from "../hooks/use-image-library";
@@ -67,6 +68,25 @@ const MODE_STORAGE_KEY = "nai-generation-mode";
 export function GenerateWorkspace() {
   const t = useT();
   const [form, setForm] = useState<FormState>(INITIAL_FORM);
+  const { data: settings } = useSettings();
+
+  // The saved default model, applied once when settings arrive. Only while the
+  // form still holds the built-in fallback: a model the person already picked
+  // in the first moments must not be snatched back.
+  const appliedDefaultModel = useRef(false);
+  useEffect(() => {
+    if (appliedDefaultModel.current || !settings) return;
+    appliedDefaultModel.current = true;
+    const saved = MODEL_OPTIONS.find(
+      (option) => option.value === settings.defaultModel
+    )?.value;
+    if (!saved) return;
+    setForm((current) =>
+      current.model === INITIAL_FORM.model
+        ? { ...current, model: saved }
+        : current
+    );
+  }, [settings]);
   const { situations: situationList } = useSituations();
   const { characters: characterList } = useCharacters();
   const { styles: styleList } = useStyles();

--- a/apps/web/src/features/generate/constants.ts
+++ b/apps/web/src/features/generate/constants.ts
@@ -87,7 +87,9 @@ export const DEFAULT_CHARACTER = {
 export const INITIAL_FORM: FormState = {
   prompt: "",
   negativePrompt: "",
-  model: "nai-diffusion-4-5-full",
+  // Matches the server's DEFAULT_MODEL; the saved default replaces it the
+  // moment settings arrive (generate-workspace).
+  model: "nai-diffusion-5-full",
   size: "portrait",
   sampler: "k_euler_ancestral",
   noiseSchedule: "karras",

--- a/apps/web/src/features/settings/components/settings-dialog.tsx
+++ b/apps/web/src/features/settings/components/settings-dialog.tsx
@@ -21,7 +21,7 @@ import { Separator } from "@nai-desktop-studio/ui/components/separator";
 import { useState } from "react";
 import { toast } from "sonner";
 
-import { PANEL_SECTIONS } from "@/features/generate/constants";
+import { MODEL_OPTIONS, PANEL_SECTIONS } from "@/features/generate/constants";
 import type { MessageKey } from "@/i18n/messages";
 import { useT } from "@/i18n/provider";
 
@@ -91,6 +91,17 @@ export function SettingsDialog({ open, onOpenChange }: Props) {
       : [...openSections, id];
     try {
       await saveSettings.mutateAsync({ openSections: next });
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : t("settings.output.errorSave")
+      );
+    }
+  }
+
+  async function handleChangeModel(defaultModel: string) {
+    try {
+      await saveSettings.mutateAsync({ defaultModel });
+      toast.success(t("settings.model.saved"));
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : t("settings.output.errorSave")
@@ -218,6 +229,45 @@ export function SettingsDialog({ open, onOpenChange }: Props) {
             </Select>
             <p className="text-muted-foreground text-xs">
               {t("settings.mode.help")}
+            </p>
+          </section>
+
+          <Separator />
+
+          <section className="space-y-2">
+            <Label htmlFor="default-model">{t("settings.model.label")}</Label>
+            <Select
+              value={
+                MODEL_OPTIONS.find(
+                  (option) => option.value === settings?.defaultModel
+                )?.value ?? "nai-diffusion-5-full"
+              }
+              items={MODEL_OPTIONS.map((option) => ({
+                value: option.value,
+                label: option.label,
+              }))}
+              onValueChange={(value) => {
+                const option = MODEL_OPTIONS.find(
+                  (item) => item.value === value
+                );
+                if (option && option.value !== settings?.defaultModel) {
+                  void handleChangeModel(option.value);
+                }
+              }}
+            >
+              <SelectTrigger id="default-model" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {MODEL_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-muted-foreground text-xs">
+              {t("settings.model.help")}
             </p>
           </section>
 

--- a/apps/web/src/i18n/messages/settings.ts
+++ b/apps/web/src/i18n/messages/settings.ts
@@ -46,6 +46,11 @@ const en = {
   "settings.output.saved": "Output folder updated",
   "settings.output.errorSave": "Could not save",
 
+  "settings.model.label": "Default model",
+  "settings.model.saved": "Default model updated",
+  "settings.model.help":
+    "The model already selected when the app opens. Each run can still switch models freely.",
+
   "settings.sections.label": "Sections open by default",
   "settings.sections.help":
     "Which parts of the generate panel are already expanded when the app opens.",
@@ -98,6 +103,11 @@ const ja: Record<keyof typeof en, string> = {
   "settings.output.errorEmpty": "保存先を入力してください",
   "settings.output.saved": "保存先を変更しました",
   "settings.output.errorSave": "保存に失敗しました",
+
+  "settings.model.label": "デフォルトモデル",
+  "settings.model.saved": "デフォルトモデルを変更しました",
+  "settings.model.help":
+    "起動した時点で選択されているモデルです。生成ごとの切り替えは今までどおりできます。",
 
   "settings.sections.label": "最初から開くセクション",
   "settings.sections.help":


### PR DESCRIPTION
## 変更内容

Closes #41

起動時に選択されているモデルを設定から変更できるようにし、既定を V5(nai-diffusion-5-full)にした。

サーバは `defaultModel` を最初から保存・返却できたのに、**web がどこからも読んでいなかった**。
生成フォームは `INITIAL_FORM` 固定の 4.5-full で必ず始まり、設定画面にも項目が無かった。

- サーバの `DEFAULT_MODEL` と web の `INITIAL_FORM.model` を V5 に(2 か所は設定が届くまでの
  つなぎで、届いた瞬間に保存値へ置き換わる)
- 設定に「デフォルトモデル」の Select。既存の Plan / 生成モードと同じ即保存 + トースト
- ワークスペースが設定の到着時に一度だけフォームへ反映する。**設定が届く前にユーザーが
  モデルを触っていたら上書きしない**(組み込みの初期値のままのときだけ置き換える)

## 確認したこと

- [x] `bun run check`(oxlint + oxfmt)
- [x] `bun run check-types`
- [x] `bun run build`
- [x] **隔離したサーバで実測** — 新規状態の `GET /settings` が `nai-diffusion-5-full`、
      `PUT` の往復と `settings.json` への保存、不正なモデル名は 400
- [x] **ブラウザで一巡** — 起動時のフォームが V5 Full → 設定のピッカーで V4.5 Full に変更 →
      サーバ保存を確認 → リロードでフォームが V4.5 Full で始まる。コンソールエラー 0。
      検証後にデフォルトは V5 へ戻し済み

## 備考

参照ライブラリのエンコードモデル(`ENCODE_MODEL` = 4.5-full 固定)は触っていない。
エンコード結果はモデル固有で、既定の変更に追随させると保存済みキャッシュが全部無効になる。