### PR TITLE
feat(references): add a vibe store managed like characters

### DIFF
--- a/apps/web/src/features/generate/components/reference-settings.tsx
+++ b/apps/web/src/features/generate/components/reference-settings.tsx
@@ -19,6 +19,7 @@ import { toast } from "sonner";
 
 import { LabeledSlider } from "@/components/labeled-slider";
 import { SegmentedControl } from "@/components/segmented-control";
+import { ReferenceManagerDialog } from "@/features/reference-library/components/reference-manager-dialog";
 import { ReferencePickerDialog } from "@/features/reference-library/components/reference-picker-dialog";
 import { referenceImageUrl } from "@/features/reference-library/lib/api";
 import { useReferences } from "@/features/reference-library/hooks/queries";
@@ -316,6 +317,7 @@ type Props = {
  */
 export function ReferenceSettings({ form, update }: Props) {
   const [libraryOpen, setLibraryOpen] = useState(false);
+  const [storeOpen, setStoreOpen] = useState(false);
   const { references } = useReferences();
   const picked = pickedLibraryReferences(form, references);
   const t = useT();
@@ -606,6 +608,12 @@ export function ReferenceSettings({ form, update }: Props) {
         onSelectedChange={(libraryReferenceIds) =>
           update({ libraryReferenceIds })
         }
+        onManage={() => setStoreOpen(true)}
+      />
+      <ReferenceManagerDialog
+        open={storeOpen}
+        onOpenChange={setStoreOpen}
+        kind={form.referenceMode}
       />
     </div>
   );

--- a/apps/web/src/features/reference-library/components/reference-entry-editor.tsx
+++ b/apps/web/src/features/reference-library/components/reference-entry-editor.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ScrollArea } from "@nai-desktop-studio/ui/components/scroll-area";
+
+import type { MessageKey } from "@/i18n/messages";
+import { useT } from "@/i18n/provider";
+
+import { referenceImageUrl } from "../lib/api";
+import {
+  REFERENCE_KIND_LABEL_KEYS,
+  type ReferenceEntry,
+} from "../types/reference";
+import {
+  ReferenceEntryFields,
+  ReferenceEntryStatus,
+} from "./reference-entry-fields";
+
+type Props = {
+  entry: ReferenceEntry;
+  /** Group names the library already uses. */
+  groupOptions: readonly string[];
+  onChange: (next: ReferenceEntry) => void;
+};
+
+/**
+ * Editor for one saved entry. The image is fixed — a different image is a
+ * different entry — so it is shown, not edited, and only the settings around
+ * it change.
+ */
+export function ReferenceEntryEditor({ entry, groupOptions, onChange }: Props) {
+  const t = useT();
+
+  function patch(next: Partial<ReferenceEntry>) {
+    onChange({ ...entry, ...next });
+  }
+
+  return (
+    <ScrollArea className="min-h-0 flex-1">
+      <div className="flex items-start gap-4 p-4">
+        <span className="bg-muted block size-40 shrink-0 overflow-hidden rounded-md border">
+          <img
+            src={referenceImageUrl(entry.id)}
+            alt=""
+            decoding="async"
+            className="size-full object-cover"
+          />
+        </span>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="bg-muted rounded-full border px-2 py-0.5 text-[10px]">
+              {t(REFERENCE_KIND_LABEL_KEYS[entry.kind] as MessageKey)}
+            </span>
+            <ReferenceEntryStatus entry={entry} />
+          </div>
+          <ReferenceEntryFields
+            entry={entry}
+            groupOptions={groupOptions}
+            onPatch={patch}
+          />
+        </div>
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/web/src/features/reference-library/components/reference-entry-fields.tsx
+++ b/apps/web/src/features/reference-library/components/reference-entry-fields.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Button } from "@nai-desktop-studio/ui/components/button";
+import { Input } from "@nai-desktop-studio/ui/components/input";
+import { Label } from "@nai-desktop-studio/ui/components/label";
+import { cn } from "@nai-desktop-studio/ui/lib/utils";
+
+import { Coins, Zap } from "lucide-react";
+
+import { GroupField } from "@/components/group-field";
+import { LabeledSlider } from "@/components/labeled-slider";
+import { REFERENCE_TYPES } from "@/features/generate/types/reference";
+import type { ReferenceType } from "@/features/generate/types/reference";
+import { useT } from "@/i18n/provider";
+
+import type { ReferenceEntry } from "../types/reference";
+
+/**
+ * What using this entry costs. An unencoded vibe is the one thing here that
+ * will spend Anlas, so it alone gets the accent colour.
+ */
+export function ReferenceEntryStatus({ entry }: { entry: ReferenceEntry }) {
+  const t = useT();
+
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1 font-mono text-[10px]",
+        entry.kind === "vibe" && !entry.encodedAt
+          ? "text-primary"
+          : "text-muted-foreground"
+      )}
+    >
+      {entry.kind === "vibe" &&
+        (entry.encodedAt ? (
+          <Zap className="size-2.5" aria-hidden />
+        ) : (
+          <Coins className="size-2.5" aria-hidden />
+        ))}
+      {entry.kind === "reference"
+        ? t("referenceLibrary.preciseCost")
+        : entry.encodedAt
+          ? t("referenceLibrary.encoded")
+          : t("referenceLibrary.notEncoded")}
+    </span>
+  );
+}
+
+type Props = {
+  entry: ReferenceEntry;
+  /** Group names the library already uses. */
+  groupOptions: readonly string[];
+  onPatch: (patch: Partial<ReferenceEntry>) => void;
+};
+
+/**
+ * The editable settings of one saved entry: name, group and the controls its
+ * kind uses. Shared by the picker's side panel and the store dialog, so the
+ * two places cannot drift apart.
+ */
+export function ReferenceEntryFields({ entry, groupOptions, onPatch }: Props) {
+  const t = useT();
+
+  return (
+    <>
+      <div className="space-y-1">
+        <Label htmlFor={`reference-name-${entry.id}`}>
+          {t("referenceLibrary.name")}
+        </Label>
+        <Input
+          id={`reference-name-${entry.id}`}
+          value={entry.name}
+          onChange={(event) => onPatch({ name: event.target.value })}
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor={`reference-group-${entry.id}`}>
+          {t("group.label")}
+        </Label>
+        <GroupField
+          id={`reference-group-${entry.id}`}
+          value={entry.groupName}
+          options={groupOptions}
+          onChange={(groupName) => onPatch({ groupName })}
+        />
+      </div>
+
+      <LabeledSlider
+        label={t("reference.strength")}
+        value={entry.strength}
+        min={0.01}
+        max={1}
+        step={0.01}
+        onChange={(strength) => onPatch({ strength })}
+      />
+
+      {entry.kind === "vibe" ? (
+        <div className="space-y-1.5">
+          <LabeledSlider
+            label={t("reference.infoExtracted")}
+            value={entry.infoExtracted}
+            min={0.01}
+            max={1}
+            step={0.01}
+            onChange={(infoExtracted) => onPatch({ infoExtracted })}
+          />
+          <p className="text-muted-foreground/80 text-[10px] leading-relaxed">
+            {t("referenceLibrary.infoExtractedHint")}
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-1">
+            <Label>{t("reference.mode.precise")}</Label>
+            <div className="flex flex-wrap gap-1">
+              {REFERENCE_TYPES.map((type: ReferenceType) => (
+                <Button
+                  key={type}
+                  type="button"
+                  size="xs"
+                  variant={
+                    entry.referenceType === type ? "secondary" : "outline"
+                  }
+                  className={cn(
+                    entry.referenceType === type && "border-primary"
+                  )}
+                  onClick={() => onPatch({ referenceType: type })}
+                >
+                  {t(
+                    type === "character"
+                      ? "reference.type.character"
+                      : type === "style"
+                        ? "reference.type.style"
+                        : "reference.type.characterStyle"
+                  )}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <LabeledSlider
+            label={t("reference.fidelity")}
+            value={entry.fidelity}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={(fidelity) => onPatch({ fidelity })}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/reference-library/components/reference-entry-list.tsx
+++ b/apps/web/src/features/reference-library/components/reference-entry-list.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { Button } from "@nai-desktop-studio/ui/components/button";
+import { Input } from "@nai-desktop-studio/ui/components/input";
+import { ScrollArea } from "@nai-desktop-studio/ui/components/scroll-area";
+import { cn } from "@nai-desktop-studio/ui/lib/utils";
+import { Copy, ImagePlus, Loader2, Search, Trash2 } from "lucide-react";
+import { useMemo, useRef } from "react";
+
+import { useT } from "@/i18n/provider";
+
+import { referenceImageUrl } from "../lib/api";
+import {
+  searchableReferenceText,
+  type ReferenceEntry,
+} from "../types/reference";
+import { ReferenceEntryStatus } from "./reference-entry-fields";
+
+type Props = {
+  entries: ReferenceEntry[];
+  selectedId: string | null;
+  search: string;
+  onSearchChange: (value: string) => void;
+  onSelect: (id: string) => void;
+  /** Creating needs an image, so "new" is a file pick rather than a button. */
+  onAdd: (file: File) => void;
+  adding: boolean;
+  onDuplicate: (entry: ReferenceEntry) => void;
+  onDelete: (entry: ReferenceEntry) => void;
+};
+
+type Group = { key: string; label: string; items: ReferenceEntry[] };
+
+/** Group by `groupName`, keeping the ungrouped bucket last. */
+function groupEntries(list: ReferenceEntry[], ungroupedLabel: string): Group[] {
+  const groups = new Map<string, ReferenceEntry[]>();
+  for (const entry of list) {
+    const key = entry.groupName ?? "";
+    groups.set(key, [...(groups.get(key) ?? []), entry]);
+  }
+
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => {
+      if (!a) return 1;
+      if (!b) return -1;
+      return a.localeCompare(b, "ja");
+    })
+    .map(([key, items]) => ({
+      key: key || "ungrouped",
+      label: key || ungroupedLabel,
+      items,
+    }));
+}
+
+/** One row: picture, name and what using the entry costs. */
+function EntryRow({
+  entry,
+  selected,
+  onSelect,
+  onDuplicate,
+  onDelete,
+}: {
+  entry: ReferenceEntry;
+  selected: boolean;
+  onSelect: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  const t = useT();
+
+  return (
+    <div
+      className={cn(
+        "group flex items-stretch rounded-sm border transition-colors",
+        selected
+          ? "border-primary bg-muted/50"
+          : "border-border hover:bg-muted/30"
+      )}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex min-w-0 flex-1 items-center gap-2 px-2.5 py-2 text-left outline-none"
+      >
+        <img
+          src={referenceImageUrl(entry.id)}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          className="size-8 shrink-0 rounded-sm border object-cover"
+        />
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate text-xs font-medium" title={entry.name}>
+            {entry.name}
+          </span>
+          <ReferenceEntryStatus entry={entry} />
+        </span>
+      </button>
+      <div className="flex shrink-0 items-center gap-0.5 pr-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          title={t("referenceStore.duplicate")}
+          onClick={onDuplicate}
+        >
+          <Copy />
+          <span className="sr-only">{t("referenceStore.duplicate")}</span>
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          title={t("action.delete")}
+          onClick={onDelete}
+        >
+          <Trash2 />
+          <span className="sr-only">{t("action.delete")}</span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ReferenceEntryList({
+  entries,
+  selectedId,
+  search,
+  onSearchChange,
+  onSelect,
+  onAdd,
+  adding,
+  onDuplicate,
+  onDelete,
+}: Props) {
+  const t = useT();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return entries;
+    return entries.filter((entry) =>
+      searchableReferenceText(entry).includes(query)
+    );
+  }, [entries, search]);
+
+  const groups = useMemo(
+    () => groupEntries(filtered, t("group.none")),
+    [filtered, t]
+  );
+
+  return (
+    <div className="flex min-h-0 w-60 shrink-0 flex-col border-r">
+      <div className="flex shrink-0 items-center gap-2 border-b p-2">
+        <div className="relative flex-1">
+          <Search
+            className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2"
+            aria-hidden
+          />
+          <Input
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder={t("referenceLibrary.search")}
+            className="h-7 pl-7"
+          />
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            // Reset every time so the same file can be picked again.
+            event.target.value = "";
+            if (file) onAdd(file);
+          }}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          title={t("referenceLibrary.add")}
+          disabled={adding}
+          onClick={() => inputRef.current?.click()}
+        >
+          {adding ? <Loader2 className="animate-spin" /> : <ImagePlus />}
+          <span className="sr-only">{t("referenceLibrary.add")}</span>
+        </Button>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-3 p-2">
+          {entries.length === 0 ? (
+            <p className="text-muted-foreground rounded-sm border border-dashed p-4 text-center text-xs">
+              {t("referenceLibrary.empty")}
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="text-muted-foreground rounded-sm border border-dashed p-4 text-center text-xs">
+              {t("referenceLibrary.noMatch")}
+            </p>
+          ) : (
+            groups.map((group) => (
+              <section key={group.key} className="space-y-1.5">
+                <div className="flex items-center gap-1.5 px-0.5">
+                  <h3 className="text-muted-foreground text-[11px] font-medium">
+                    {group.label}
+                  </h3>
+                  <span className="text-muted-foreground/70 font-mono text-[10px] tabular-nums">
+                    {group.items.length}
+                  </span>
+                </div>
+                <div className="space-y-1">
+                  {group.items.map((entry) => (
+                    <EntryRow
+                      key={entry.id}
+                      entry={entry}
+                      selected={entry.id === selectedId}
+                      onSelect={() => onSelect(entry.id)}
+                      onDuplicate={() => onDuplicate(entry)}
+                      onDelete={() => onDelete(entry)}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/web/src/features/reference-library/components/reference-manager-dialog.tsx
+++ b/apps/web/src/features/reference-library/components/reference-manager-dialog.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@nai-desktop-studio/ui/components/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@nai-desktop-studio/ui/components/dialog";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { collectGroupNames } from "@/components/group-field";
+import { readImageFile } from "@/features/generate/lib/image-file";
+import { useT } from "@/i18n/provider";
+
+import { duplicateReferenceInput, useReferences } from "../hooks/queries";
+import {
+  createEmptyReference,
+  type ReferenceEntry,
+  type ReferenceKind,
+} from "../types/reference";
+import { ReferenceEntryEditor } from "./reference-entry-editor";
+import { ReferenceEntryList } from "./reference-entry-list";
+
+const AUTOSAVE_DELAY_MS = 400;
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Which side of the library this store shows: vibes or precise references. */
+  kind: ReferenceKind;
+};
+
+/**
+ * The vibe store: manages the saved entries of one kind the way the character
+ * manager does — a searchable, grouped list beside an editor. The selected
+ * entry is edited in a detached draft and written back with a debounced
+ * autosave, so typing never blocks on the network and the list stays driven by
+ * the query cache.
+ */
+export function ReferenceManagerDialog({ open, onOpenChange, kind }: Props) {
+  const t = useT();
+  const { references, isPending, create, save, remove } = useReferences();
+
+  const [draft, setDraft] = useState<ReferenceEntry | null>(null);
+  const [search, setSearch] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<ReferenceEntry | null>(null);
+
+  // Autosave state lives in refs: the pending draft is captured per edit, so a
+  // scheduled write still lands for the right entry after the selection or
+  // dialog changes. `save`/`t` are mirrored so `flush` can stay identity-stable.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<ReferenceEntry | null>(null);
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  const flush = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const pending = pendingRef.current;
+    pendingRef.current = null;
+    if (!pending) return;
+    saveRef.current.mutate(pending, {
+      // The server owns `encodedAt` — changing infoExtracted drops the stored
+      // encode — so fold it back into the draft. Only that field and the
+      // timestamps, so edits typed while the save was in flight survive.
+      onSuccess: (saved) => {
+        setDraft((current) =>
+          current && current.id === saved.id
+            ? {
+                ...current,
+                encodedAt: saved.encodedAt,
+                updatedAt: saved.updatedAt,
+              }
+            : current
+        );
+      },
+      onError: (error) =>
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : tRef.current("referenceLibrary.saveError")
+        ),
+    });
+  }, []);
+
+  const scheduleSave = useCallback(
+    (next: ReferenceEntry) => {
+      pendingRef.current = next;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(flush, AUTOSAVE_DELAY_MS);
+    },
+    [flush]
+  );
+
+  // Persist a pending edit when the dialog closes and on unmount.
+  useEffect(() => {
+    if (!open) flush();
+  }, [open, flush]);
+  useEffect(() => () => flush(), [flush]);
+
+  const ofKind = useMemo(
+    () => references.filter((entry) => entry.kind === kind),
+    [references, kind]
+  );
+
+  // Select the first entry when opening with nothing selected. The dialog is
+  // reused for both kinds, so a draft of the other kind counts as nothing.
+  useEffect(() => {
+    if (!open || draft?.kind === kind) return;
+    setDraft(ofKind[0] ?? null);
+  }, [open, draft, kind, ofKind]);
+
+  // The cache lags edits by the debounce, so show the live draft in the list.
+  const listEntries = useMemo(() => {
+    if (!draft || draft.kind !== kind) return ofKind;
+    return ofKind.some((item) => item.id === draft.id)
+      ? ofKind.map((item) => (item.id === draft.id ? draft : item))
+      : [draft, ...ofKind];
+  }, [ofKind, draft, kind]);
+
+  const groupOptions = useMemo(
+    () => collectGroupNames(listEntries),
+    [listEntries]
+  );
+
+  const handleChange = useCallback(
+    (next: ReferenceEntry) => {
+      setDraft(next);
+      scheduleSave(next);
+    },
+    [scheduleSave]
+  );
+
+  function selectEntry(id: string) {
+    if (id === draft?.id) return;
+    flush();
+    const found = ofKind.find((item) => item.id === id);
+    if (found) setDraft(found);
+  }
+
+  async function handleAdd(file: File) {
+    const read = await readImageFile(file);
+    if (!read.ok) {
+      toast.error(
+        read.reason === "not-image"
+          ? t("reference.error.notImage")
+          : t("reference.error.tooLarge")
+      );
+      return;
+    }
+    // Only the bytes are needed; the list shows the server's copy.
+    URL.revokeObjectURL(read.previewUrl);
+    flush();
+    const seed = createEmptyReference(
+      kind,
+      file.name.replace(/\.[^.]+$/, "") || t("referenceLibrary.newName")
+    );
+    try {
+      const entry = await create.mutateAsync({
+        metadata: {
+          name: seed.name,
+          groupName: seed.groupName,
+          kind: seed.kind,
+          strength: seed.strength,
+          infoExtracted: seed.infoExtracted,
+          referenceType: seed.referenceType,
+          fidelity: seed.fidelity,
+        },
+        imageBase64: read.imageBase64,
+        contentType: file.type || "image/png",
+      });
+      setDraft(entry);
+    } catch {
+      toast.error(t("referenceLibrary.saveError"));
+    }
+  }
+
+  async function handleDuplicate(source: ReferenceEntry) {
+    flush();
+    const input = await duplicateReferenceInput(
+      source,
+      t("referenceStore.copyName", { name: source.name })
+    );
+    if (!input) {
+      toast.error(t("referenceStore.duplicateError"));
+      return;
+    }
+    try {
+      setDraft(await create.mutateAsync(input));
+    } catch {
+      toast.error(t("referenceStore.duplicateError"));
+    }
+  }
+
+  async function confirmDelete() {
+    const target = deleteTarget;
+    if (!target) return;
+    // Drop any pending autosave for this item so a late write can't resurrect it.
+    if (pendingRef.current?.id === target.id) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = null;
+      pendingRef.current = null;
+    }
+    try {
+      await remove.mutateAsync(target);
+      if (draft?.id === target.id) {
+        setDraft(ofKind.find((item) => item.id !== target.id) ?? null);
+      }
+      toast.success(t("referenceStore.deleted", { name: target.name }));
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : t("referenceStore.deleteError")
+      );
+    } finally {
+      setDeleteTarget(null);
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="flex h-[80vh] max-w-4xl flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl">
+          <DialogHeader className="shrink-0 border-b px-4 py-3">
+            <DialogTitle>
+              {t(
+                kind === "vibe"
+                  ? "referenceStore.vibeTitle"
+                  : "referenceStore.referenceTitle"
+              )}
+            </DialogTitle>
+          </DialogHeader>
+
+          <div className="flex min-h-0 flex-1">
+            <ReferenceEntryList
+              entries={listEntries}
+              selectedId={draft?.id ?? null}
+              search={search}
+              onSearchChange={setSearch}
+              onSelect={selectEntry}
+              onAdd={(file) => void handleAdd(file)}
+              adding={create.isPending}
+              onDuplicate={(entry) => void handleDuplicate(entry)}
+              onDelete={setDeleteTarget}
+            />
+
+            {draft ? (
+              <ReferenceEntryEditor
+                entry={draft}
+                groupOptions={groupOptions}
+                onChange={handleChange}
+              />
+            ) : (
+              <div className="text-muted-foreground flex min-h-0 flex-1 items-center justify-center p-6 text-center text-xs">
+                {isPending ? null : t("referenceStore.noSelection")}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(value) => {
+          if (!value && !remove.isPending) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("referenceStore.deleteTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("referenceStore.deleteDescription", {
+                name: deleteTarget?.name ?? "",
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={remove.isPending}>
+              {t("action.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={remove.isPending}
+              onClick={() => void confirmDelete()}
+            >
+              {t("action.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/src/features/reference-library/components/reference-picker-dialog.tsx
+++ b/apps/web/src/features/reference-library/components/reference-picker-dialog.tsx
@@ -9,17 +9,13 @@ import {
   DialogTitle,
 } from "@nai-desktop-studio/ui/components/dialog";
 import { Input } from "@nai-desktop-studio/ui/components/input";
-import { Label } from "@nai-desktop-studio/ui/components/label";
 import { cn } from "@nai-desktop-studio/ui/lib/utils";
-import { Coins, ImagePlus, Loader2, Search, Trash2, Zap } from "lucide-react";
+import { ImagePlus, Loader2, Search, Settings2, Trash2 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { GroupField, collectGroupNames } from "@/components/group-field";
-import { LabeledSlider } from "@/components/labeled-slider";
+import { collectGroupNames } from "@/components/group-field";
 import { readImageFile } from "@/features/generate/lib/image-file";
-import { REFERENCE_TYPES } from "@/features/generate/types/reference";
-import type { ReferenceType } from "@/features/generate/types/reference";
 import { useT } from "@/i18n/provider";
 
 import { useReferences } from "../hooks/queries";
@@ -30,6 +26,10 @@ import {
   type ReferenceEntry,
   type ReferenceKind,
 } from "../types/reference";
+import {
+  ReferenceEntryFields,
+  ReferenceEntryStatus,
+} from "./reference-entry-fields";
 
 type Props = {
   open: boolean;
@@ -38,6 +38,8 @@ type Props = {
   kind: ReferenceKind;
   selectedIds: string[];
   onSelectedChange: (ids: string[]) => void;
+  /** Opens the vibe store, so a missing image can be added and filed here. */
+  onManage: () => void;
   /**
    * How many more images this run has room for. A request is capped whatever
    * the images came from, so what the panel already holds counts against this.
@@ -59,6 +61,7 @@ export function ReferencePickerDialog({
   kind,
   selectedIds,
   onSelectedChange,
+  onManage,
   remaining,
 }: Props) {
   const t = useT();
@@ -212,6 +215,16 @@ export function ReferencePickerDialog({
             {busy ? <Loader2 className="animate-spin" /> : <ImagePlus />}
             {t("referenceLibrary.add")}
           </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={onManage}
+          >
+            <Settings2 />
+            {t("generate.picker.manage")}
+          </Button>
         </div>
 
         <div className="flex min-h-0 flex-1 gap-3">
@@ -271,28 +284,7 @@ export function ReferencePickerDialog({
                               </span>
                               {/* Encoded or not is the only thing here that
                                   costs money, so it gets the colour. */}
-                              <span
-                                className={cn(
-                                  "flex items-center gap-1 font-mono text-[10px]",
-                                  entry.kind === "reference"
-                                    ? "text-muted-foreground"
-                                    : entry.encodedAt
-                                      ? "text-muted-foreground"
-                                      : "text-primary"
-                                )}
-                              >
-                                {entry.kind === "vibe" &&
-                                  (entry.encodedAt ? (
-                                    <Zap className="size-2.5" aria-hidden />
-                                  ) : (
-                                    <Coins className="size-2.5" aria-hidden />
-                                  ))}
-                                {entry.kind === "reference"
-                                  ? t("referenceLibrary.preciseCost")
-                                  : entry.encodedAt
-                                    ? t("referenceLibrary.encoded")
-                                    : t("referenceLibrary.notEncoded")}
-                              </span>
+                              <ReferenceEntryStatus entry={entry} />
                             </span>
                             {selected && (
                               <span className="bg-primary text-primary-foreground ring-background absolute top-1.5 right-1.5 flex size-5 items-center justify-center rounded-full font-mono text-[10px] font-semibold tabular-nums ring-2">
@@ -312,90 +304,11 @@ export function ReferencePickerDialog({
           <div className="w-72 shrink-0 space-y-3 overflow-y-auto border-l py-1 pr-1 pl-3">
             {editing ? (
               <>
-                <div className="space-y-1">
-                  <Label htmlFor="reference-name">
-                    {t("referenceLibrary.name")}
-                  </Label>
-                  <Input
-                    id="reference-name"
-                    value={editing.name}
-                    onChange={(event) => patch({ name: event.target.value })}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="reference-group">{t("group.label")}</Label>
-                  <GroupField
-                    id="reference-group"
-                    value={editing.groupName}
-                    options={groupOptions}
-                    onChange={(groupName) => patch({ groupName })}
-                  />
-                </div>
-
-                <LabeledSlider
-                  label={t("reference.strength")}
-                  value={editing.strength}
-                  min={0.01}
-                  max={1}
-                  step={0.01}
-                  onChange={(strength) => patch({ strength })}
+                <ReferenceEntryFields
+                  entry={editing}
+                  groupOptions={groupOptions}
+                  onPatch={patch}
                 />
-
-                {editing.kind === "vibe" ? (
-                  <div className="space-y-1.5">
-                    <LabeledSlider
-                      label={t("reference.infoExtracted")}
-                      value={editing.infoExtracted}
-                      min={0.01}
-                      max={1}
-                      step={0.01}
-                      onChange={(infoExtracted) => patch({ infoExtracted })}
-                    />
-                    <p className="text-muted-foreground/80 text-[10px] leading-relaxed">
-                      {t("referenceLibrary.infoExtractedHint")}
-                    </p>
-                  </div>
-                ) : (
-                  <>
-                    <div className="space-y-1">
-                      <Label>{t("reference.mode.precise")}</Label>
-                      <div className="flex flex-wrap gap-1">
-                        {REFERENCE_TYPES.map((type: ReferenceType) => (
-                          <Button
-                            key={type}
-                            type="button"
-                            size="xs"
-                            variant={
-                              editing.referenceType === type
-                                ? "secondary"
-                                : "outline"
-                            }
-                            className={cn(
-                              editing.referenceType === type && "border-primary"
-                            )}
-                            onClick={() => patch({ referenceType: type })}
-                          >
-                            {t(
-                              type === "character"
-                                ? "reference.type.character"
-                                : type === "style"
-                                  ? "reference.type.style"
-                                  : "reference.type.characterStyle"
-                            )}
-                          </Button>
-                        ))}
-                      </div>
-                    </div>
-                    <LabeledSlider
-                      label={t("reference.fidelity")}
-                      value={editing.fidelity}
-                      min={0}
-                      max={1}
-                      step={0.01}
-                      onChange={(fidelity) => patch({ fidelity })}
-                    />
-                  </>
-                )}
 
                 <Button
                   type="button"

--- a/apps/web/src/features/reference-library/hooks/queries.ts
+++ b/apps/web/src/features/reference-library/hooks/queries.ts
@@ -2,10 +2,13 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { bytesToBase64 } from "@/lib/base64";
+
 import {
   createReference,
   deleteReference,
   listReferences,
+  referenceImageUrl,
   updateReference,
   type ReferenceMetadata,
 } from "../lib/api";
@@ -100,4 +103,37 @@ export function useReferences() {
     save,
     remove,
   };
+}
+
+/**
+ * Builds the create input for an independent copy: the image bytes are
+ * re-fetched so the copy owns its own file. The copy starts unencoded, but
+ * encoding the same image at the same settings hits the server's
+ * content-addressed cache, so it normally costs nothing until the copy's
+ * settings diverge.
+ */
+export async function duplicateReferenceInput(
+  source: ReferenceEntry,
+  name: string
+): Promise<NewReference | null> {
+  try {
+    const response = await fetch(referenceImageUrl(source.id));
+    if (!response.ok) return null;
+    const blob = await response.blob();
+    return {
+      metadata: {
+        name,
+        groupName: source.groupName,
+        kind: source.kind,
+        strength: source.strength,
+        infoExtracted: source.infoExtracted,
+        referenceType: source.referenceType,
+        fidelity: source.fidelity,
+      },
+      imageBase64: bytesToBase64(new Uint8Array(await blob.arrayBuffer())),
+      contentType: blob.type || "image/png",
+    };
+  } catch {
+    return null;
+  }
 }

--- a/apps/web/src/i18n/messages/generate.ts
+++ b/apps/web/src/i18n/messages/generate.ts
@@ -157,6 +157,18 @@ const en = {
   "referenceLibrary.atMax":
     "This run already carries as many reference images as it can.",
 
+  "referenceStore.vibeTitle": "Vibe store",
+  "referenceStore.referenceTitle": "Precise reference store",
+  "referenceStore.noSelection": "Select an image to edit",
+  "referenceStore.copyName": "{name} copy",
+  "referenceStore.duplicate": "Duplicate",
+  "referenceStore.duplicateError": "Could not copy the image",
+  "referenceStore.deleteTitle": "Delete this image?",
+  "referenceStore.deleteDescription":
+    "“{name}” will be removed, along with any stored encode. This cannot be undone.",
+  "referenceStore.deleted": "Deleted “{name}”",
+  "referenceStore.deleteError": "Could not delete the image",
+
   "generate.anlasConfirm.title": "This run spends Anlas",
   "generate.anlasConfirm.description":
     "The reference images add about {count} Anlas on top of the images themselves. Go ahead?",
@@ -370,6 +382,18 @@ const ja: Record<keyof typeof en, string> = {
     "ライブラリを読めなかったので、ライブラリ無しで生成します。",
   "referenceLibrary.dropped": "ライブラリ参照 {count} 件を除きました。",
   "referenceLibrary.atMax": "この生成で使える参照画像の上限に達しています。",
+
+  "referenceStore.vibeTitle": "バイブストア",
+  "referenceStore.referenceTitle": "精密参照ストア",
+  "referenceStore.noSelection": "編集する画像を選択してください",
+  "referenceStore.copyName": "{name} のコピー",
+  "referenceStore.duplicate": "複製",
+  "referenceStore.duplicateError": "画像を複製できませんでした",
+  "referenceStore.deleteTitle": "この画像を削除しますか？",
+  "referenceStore.deleteDescription":
+    "「{name}」を保存済みエンコードごと削除します。この操作は取り消せません。",
+  "referenceStore.deleted": "「{name}」を削除しました",
+  "referenceStore.deleteError": "画像を削除できませんでした",
 
   "generate.anlasConfirm.title": "Anlas を消費します",
   "generate.anlasConfirm.description":


### PR DESCRIPTION
## 変更内容

バイブ（Vibe Transfer 画像）を保管・整理する「バイブストア」を追加した。保存先は既存の参照ライブラリ（`references` ストア。エンコード結果を保持して 2 Anlas を初回だけにする仕組み）のままにし、その上にキャラクター管理と同型の管理ダイアログを被せた — ストアを二重に持たないため。

- `ReferenceManagerDialog`: 左に一覧（検索・グループ・画像追加・複製・確認付き削除）、右にエディタ。キャラクター管理と同じ 400ms デバウンスの自動保存。`kind` でバイブ／精密参照の両方を兼ねる
- 参照ピッカーに他のピッカーと同じ「管理」ボタンを追加し、そこからストアを開く
- 名前・グループ・スライダー類とコスト表示をピッカーの編集パネルと共有（`ReferenceEntryFields` / `ReferenceEntryStatus`）にして二重実装を解消
- 複製は画像を取り直してコピー自身に持たせる（キャラクター複製と同じ考え方。再エンコードはコンテンツアドレスキャッシュに当たるので通常無料）
- 情報抽出度の変更でサーバーが保存済みエンコードを破棄したとき、`encodedAt` をドラフトへ反映してバッジが「エンコード済み」のまま残らないようにした

Closes #45

## 確認したこと

- [x] `bun run check`（oxlint + oxfmt）
- [x] `bun run check-types`
- [x] `bun run build`
- [x] 実際に動かして確認した

## 備考

- 実機での動作確認は未実施（ダイアログの開閉〜編集の実操作）。
- ストアから削除した項目の id が生成フォームの選択（`libraryReferenceIds`）に残り得るが、既存の resolve と `pickedLibraryReferences` が黙って読み飛ばすため実害はない（ピッカー外で削除された場合と同じ扱い）。